### PR TITLE
Allow reading file contents from stdin

### DIFF
--- a/darglint/driver.py
+++ b/darglint/driver.py
@@ -59,8 +59,8 @@ parser.add_argument(
     'files',
     nargs='*',
     help=(
-        'The python source files to check.  Any files not ending in '
-        '".py" are ignored. If "-" is given, then stdin will be read.'
+        'The python source files to check. If "-" is given, then stdin will '
+        'be read.'
     ),
 )
 parser.add_argument(
@@ -194,7 +194,7 @@ def main():
                 print(error_report + '\n')
                 encountered_errors = True
     except Exception as exc:
-        # Exit with status 2 regardless of whether user wants a
+        # Exit with status 129 regardless of whether user wants a
         # exit code or not -- darglint failed, and it should
         # look like it failed.
         print(exc, file=sys.stderr)

--- a/darglint/driver.py
+++ b/darglint/driver.py
@@ -60,7 +60,7 @@ parser.add_argument(
     nargs='*',
     help=(
         'The python source files to check.  Any files not ending in '
-        '".py" are ignored.'
+        '".py" are ignored. If "-" is given, then stdin will be read.'
     ),
 )
 parser.add_argument(
@@ -181,9 +181,8 @@ def main():
             config.style = DocstringStyle.SPHINX
         elif args.docstring_style == 'google':
             config.style = DocstringStyle.GOOGLE
-        files = [x for x in args.files if x.endswith('.py')]
         raise_errors_for_syntax = args.raise_syntax or False
-        for filename in files:
+        for filename in args.files:
             error_report = get_error_report(
                 filename,
                 args.verbosity,
@@ -194,10 +193,11 @@ def main():
             if error_report:
                 print(error_report + '\n')
                 encountered_errors = True
-    except Exception:
+    except Exception as exc:
         # Exit with status 2 regardless of whether user wants a
         # exit code or not -- darglint failed, and it should
         # look like it failed.
+        print(exc, file=sys.stderr)
         sys.exit(129)
     if encountered_errors and exit_code:
         sys.exit(1)

--- a/darglint/function_description.py
+++ b/darglint/function_description.py
@@ -1,6 +1,7 @@
 """A linter for docstrings following the google docstring format."""
 import ast
 from collections import deque
+import sys
 from typing import (
     Callable,
     Iterator,
@@ -20,15 +21,19 @@ def read_program(filename):  # type: (str) -> str
     """Read a program from a file.
 
     Args:
-        filename: The name of the file to read.
+        filename: The name of the file to read. If set to '-', then we will
+            read from stdin.
 
     Returns:
         The program as a single string.
 
     """
     program = None  # type: str
-    with open(filename, 'r') as fin:
-        program = fin.read()
+    if filename == '-':
+        program = sys.stdin.read()
+    else:
+        with open(filename, 'r') as fin:
+            program = fin.read()
     return program
 
 


### PR DESCRIPTION
This will allow the SublimtLinter plugin to lint live changes to a file being edited without an IO operation on disk that is would have to perform to create an intermediate file, in this case it can just pipe the current file contents to darglint and keep everything in memory. 

I also removed the file extension test since I know of a few other formats this just isn't true for.. salt sls files are a good example. Added a print of the error when parsing fails due to ASL failure as well.