### PR TITLE
Fix return type check for type annotations.

### DIFF
--- a/darglint/integrity_checker.py
+++ b/darglint/integrity_checker.py
@@ -184,7 +184,7 @@ class IntegrityChecker(object):
         fun_type = self.function.return_type
         doc_type = self.docstring.get_types(Sections.RETURNS_SECTION)
         if not doc_type or isinstance(doc_type, list):
-            doc_type = ''
+            doc_type = None
         if fun_type is not None and doc_type is not None:
             if fun_type != doc_type:
                 line_numbers = self.docstring.get_line_numbers(

--- a/tests/test_integrity_checker.py
+++ b/tests/test_integrity_checker.py
@@ -288,6 +288,40 @@ class IntegrityCheckerTestCase(TestCase):
         self.assertEqual(error.expected, 'int')
         self.assertEqual(error.actual, 'float')
 
+    def test_return_type_unchecked_if_not_defined_in_docstring(self):
+        program = '\n'.join([
+            'def foo() -> str:',
+            '    """Just a foobar.',
+            '',
+            '    Returns:',
+            '        bar',
+            '',
+            '    """',
+            '    return "bar"',
+        ])
+        tree = ast.parse(program)
+        functions = get_function_descriptions(tree)
+        checker = IntegrityChecker()
+        checker.run_checks(functions[0])
+        self.assertEqual(len(checker.errors), 0)
+
+    def test_return_type_unchecked_if_not_defined_in_function(self):
+        program = '\n'.join([
+            'def foo():',
+            '    """Just a foobar.',
+            '',
+            '    Returns:',
+            '        str: bar',
+            '',
+            '    """',
+            '    return "bar"',
+        ])
+        tree = ast.parse(program)
+        functions = get_function_descriptions(tree)
+        checker = IntegrityChecker()
+        checker.run_checks(functions[0])
+        self.assertEqual(len(checker.errors), 0)
+
     def test_return_type_checked_if_defined_in_docstring_and_function(self):
         program = '\n'.join([
             'def update_model(x: dict) -> dict:',


### PR DESCRIPTION
Fix bypass logic for ReturnTypeMismatchError in integrity_checker.py,
allowing declaring to return type exclusively type annotations or
docstring type annotations.

Fixes #23