### PR TITLE
Adding support for keyword only arguments

### DIFF
--- a/darglint/function_description.py
+++ b/darglint/function_description.py
@@ -58,6 +58,9 @@ def _get_arguments(fn):
     for arg in fn.args.args:
         add_arg_by_name(arg.arg, arg)
 
+    for arg in fn.args.kwonlyargs:
+        add_arg_by_name(arg.arg, arg)
+
     # Handle single-star arguments.
     if fn.args.vararg is not None:
         name = '*' + fn.args.vararg.arg

--- a/tests/test_function_description.py
+++ b/tests/test_function_description.py
@@ -172,3 +172,13 @@ class GetFunctionsAndDocstrings(TestCase):
         tree = ast.parse(program)
         function = get_function_descriptions(tree)[0]
         self.assertTrue(function.has_return)
+
+    def test_keyword_only_arguments(self):
+        """PEP 3102"""
+        program = '\n'.join([
+            'def random_function(a, b, *, key=None):'
+            '   pass'
+        ])
+        tree = ast.parse(program)
+        function = get_function_descriptions(tree)[0]
+        self.assertEqual(function.argument_names, ["a", "b", "key"])

--- a/tests/test_function_description.py
+++ b/tests/test_function_description.py
@@ -181,4 +181,15 @@ class GetFunctionsAndDocstrings(TestCase):
         ])
         tree = ast.parse(program)
         function = get_function_descriptions(tree)[0]
-        self.assertEqual(function.argument_names, ["a", "b", "key"])
+        self.assertEqual(function.argument_names, ['a', 'b', 'key'])
+        self.assertEqual(function.argument_types, [None, None, None])
+
+    def test_keyword_only_arguments_with_type_hints(self):
+        program = '\n'.join([
+            'def random_function(*, a: int, key: bool=True):'
+            '   pass'
+        ])
+        tree = ast.parse(program)
+        function = get_function_descriptions(tree)[0]
+        self.assertEqual(function.argument_names, ['a', 'key'])
+        self.assertEqual(function.argument_types, ['int', 'bool'])


### PR DESCRIPTION
PEP 3102 (Python 3.0) added keyword only arguments: https://www.python.org/dev/peps/pep-3102/

This PR adds support for these. Previously they have been silently ignored.

Could not find a lot of information about your preferred coding style and what not so please let me know if this is okay.