### PR TITLE
Optionally test for missing docstrings

### DIFF
--- a/darglint/config.py
+++ b/darglint/config.py
@@ -88,7 +88,8 @@ def load_config_file(filename):  # type: (str) -> Configuration
                     )
                 )
         if 'raise_on_missing_docstrings' in config['darglint']:
-            raise_on_missing_docstrings = config['darglint']['raise_on_missing_docstrings']
+            raise_on_missing_docstrings = config.getboolean(
+                'darglint', 'raise_on_missing_docstrings')
 
     return Configuration(
         ignore=ignore,

--- a/darglint/config.py
+++ b/darglint/config.py
@@ -31,19 +31,22 @@ POSSIBLE_CONFIG_FILENAMES = (
 
 class Configuration(object):
 
-    def __init__(self, ignore, message_template, style):
-        # type: (List[str], Optional[str], DocstringStyle) -> None
+    def __init__(self, ignore, message_template, style, raise_on_missing_docstrings):
+        # type: (List[str], Optional[str], DocstringStyle, bool) -> None
         """Initialize the configuration object.
 
         Args:
             ignore: A list of error codes to ignore.
             message_template: the template with which to format the errors.
             style: The style of docstring.
+            raise_on_missing_docstrings: Report an error if a public function or method
+                is missing a docstring.
 
         """
         self.ignore = ignore
         self.message_template = message_template
         self.style = style
+        self.raise_on_missing_docstrings = raise_on_missing_docstrings
 
 
 def load_config_file(filename):  # type: (str) -> Configuration
@@ -64,6 +67,7 @@ def load_config_file(filename):  # type: (str) -> Configuration
     ignore = list()
     message_template = None
     style = DocstringStyle.GOOGLE
+    raise_on_missing_docstrings = False
     if 'darglint' in config.sections():
         if 'ignore' in config['darglint']:
             errors = config['darglint']['ignore']
@@ -83,10 +87,14 @@ def load_config_file(filename):  # type: (str) -> Configuration
                         [x.name for x in DocstringStyle]
                     )
                 )
+        if 'raise_on_missing_docstrings' in config['darglint']:
+            raise_on_missing_docstrings = config['darglint']['raise_on_missing_docstrings']
+
     return Configuration(
         ignore=ignore,
         message_template=message_template,
-        style=style
+        style=style,
+        raise_on_missing_docstrings=raise_on_missing_docstrings
     )
 
 
@@ -167,7 +175,8 @@ def get_config():  # type: () -> Configuration
         return Configuration(
             ignore=list(),
             message_template=None,
-            style=DocstringStyle.GOOGLE
+            style=DocstringStyle.GOOGLE,
+            raise_on_missing_docstrings=False
         )
     return load_config_file(filename)
 

--- a/darglint/driver.py
+++ b/darglint/driver.py
@@ -92,6 +92,14 @@ parser.add_argument(
         'only google or sphinx styles are supported.'
     )
 )
+parser.add_argument(
+    '--raise-on-missing-docstrings',
+    action='store_true',
+    help=(
+        'Missing docstrings for public functions or methods are considered an '
+        'error.'
+    )
+)
 
 # ---------------------- MAIN SCRIPT ---------------------------------
 
@@ -138,6 +146,8 @@ def get_error_report(filename,
 
 def print_error_list():
     print('\n'.join([
+        'I002: Missing docstring for public method.'
+        'I003: Missing docstring for public function.'
         'I101: The docstring is missing a parameter in the definition.',
         'I102: The docstring contains a parameter not in function.',
         'I103: The docstring parameter type doesn\'t match function.',
@@ -181,6 +191,10 @@ def main():
             config.style = DocstringStyle.SPHINX
         elif args.docstring_style == 'google':
             config.style = DocstringStyle.GOOGLE
+
+        if args.raise_on_missing_docstrings:
+            config.raise_on_missing_docstrings = True
+
         raise_errors_for_syntax = args.raise_syntax or False
         for filename in args.files:
             error_report = get_error_report(

--- a/darglint/errors.py
+++ b/darglint/errors.py
@@ -8,6 +8,7 @@ Groups of errors:
     I Interface
     S Style
 
+    000 Missing docstrings
     100 Args
     200 Returns
     300 Yields
@@ -146,6 +147,50 @@ class EmptyDescriptionError(DarglintError):
         self.terse_message = 'e {}'.format(message)
 
         super(EmptyDescriptionError, self).__init__(
+            function,
+            line_numbers=line_numbers,
+        )
+
+
+class MissingDocstringForPublicMethod(DarglintError):
+    """Describes when a docstring is missing for a public method."""
+
+    error_code = 'I002'
+
+    def __init__(self, function, line_numbers=None):
+        # type: (Union[ast.FunctionDef, ast.AsyncFunctionDef], Tuple[int, int]) -> None
+        """Instantiate the error's message.
+
+        Args:
+            function: An ast node for the function.
+            line_numbers: The line numbers where this error occurs.
+
+        """
+        self.general_message = 'Missing docstring for public method'
+        self.terse_message = function.name
+        super(MissingDocstringForPublicMethod, self).__init__(
+            function,
+            line_numbers=line_numbers,
+        )
+
+
+class MissingDocstringForPublicFunction(DarglintError):
+    """Describes when a docstring is missing for a public function."""
+
+    error_code = 'I003'
+
+    def __init__(self, function, line_numbers=None):
+        # type: (Union[ast.FunctionDef, ast.AsyncFunctionDef], Tuple[int, int]) -> None
+        """Instantiate the error's message.
+
+        Args:
+            function: An ast node for the function.
+            line_numbers: The line numbers where this error occurs.
+
+        """
+        self.general_message = 'Missing docstring for public function'
+        self.terse_message = function.name
+        super(MissingDocstringForPublicFunction, self).__init__(
             function,
             line_numbers=line_numbers,
         )

--- a/tests/test_integrity_checker.py
+++ b/tests/test_integrity_checker.py
@@ -18,6 +18,8 @@ from darglint.errors import (
     MissingRaiseError,
     MissingReturnError,
     MissingYieldError,
+    MissingDocstringForPublicFunction,
+    MissingDocstringForPublicMethod,
     ParameterTypeMismatchError,
     ReturnTypeMismatchError,
 )
@@ -645,3 +647,80 @@ class IntegrityCheckerTestCase(TestCase):
         ])
         for variant in ['# noqa: *', '# noqa: S001', '# noqa']:
             self.has_no_errors(program.format(variant))
+
+        self.config = Configuration(
+            ignore=[],
+            message_template=None,
+            style=DocstringStyle.SPHINX,
+            raise_on_missing_docstrings=False
+        )
+
+    def test_check_for_missing_docstrings(self):
+        """Make sure we capture missing parameters."""
+        program = '\n'.join([
+            # Function without a docstring.
+            'def foo():',
+            '    pass',
+            # Function with a docstring.
+            'def bar():',
+            '    """"docstring"""',
+            '    pass',
+            # private function without a docstring.
+            'def _foo():',
+            '    pass',
+            'class FooBar:',
+            # Method with a docstring.
+            '    def bar_method(self):',
+            '        """docstring"""',
+            '        pass',
+            # Method without a docstring.
+            '    def foo_method(self):',
+            '        pass',
+            # Private method without a docstring.
+            '    def _foo_method(self):',
+            '        pass',
+        ])
+        tree = ast.parse(program)
+        functions = get_function_descriptions(tree)
+
+        # No errors if raise_on_missing_docstrings is False.
+        checker = IntegrityChecker(
+            Configuration(
+                ignore=[],
+                message_template=None,
+                style=DocstringStyle.GOOGLE,
+                raise_on_missing_docstrings=False
+            )
+        )
+        for f in functions:
+            checker.run_checks(f)
+        errors = checker.errors
+        self.assertEqual(len(errors), 0)
+
+        # But two errors if True.
+        checker = IntegrityChecker(
+            Configuration(
+                ignore=[],
+                message_template=None,
+                style=DocstringStyle.GOOGLE,
+                raise_on_missing_docstrings=True
+            )
+        )
+        for f in functions:
+            checker.run_checks(f)
+        errors = checker.errors
+        self.assertEqual(len(errors), 2)
+
+        # Somehow the functions are parsed methods -> functions.
+        self.assertTrue(isinstance(
+            errors[0], MissingDocstringForPublicMethod))
+        self.assertTrue(isinstance(
+            errors[1], MissingDocstringForPublicFunction))
+        self.assertEqual(errors[0].general_message,
+                         'Missing docstring for public method')
+        self.assertEqual(errors[0].terse_message,
+                         'foo_method')
+        self.assertEqual(errors[1].general_message,
+                         'Missing docstring for public function')
+        self.assertEqual(errors[1].terse_message,
+                         'foo')

--- a/tests/test_integrity_checker.py
+++ b/tests/test_integrity_checker.py
@@ -30,7 +30,8 @@ class IntegrityCheckerSphinxTestCase(TestCase):
         self.config = Configuration(
             ignore=[],
             message_template=None,
-            style=DocstringStyle.SPHINX
+            style=DocstringStyle.SPHINX,
+            raise_on_missing_docstrings=False
         )
 
     def test_missing_parameter(self):


### PR DESCRIPTION
It is pretty useful to be able to enforce that docstrings exist. This PR adds a new CLI flag `--raise-on-missing-docstrings` that, as the name implies, raises errors if docstrings for public functions or methods do not exist.

Support has also been added to the config object and files.

The error codes

* `I002: Missing docstring for public method.`
* `I003: Missing docstring for public function.`

are inspired by the `pydocstyle` errors: https://github.com/PyCQA/pydocstyle/blob/cc5a96b356e2f10e8c95f1ca719efa3380237671/src/pydocstyle/violations.py#L171

The `I1XX` group has already been taken so I used the `I0XX` group.

I'm not sure if you'd like to guard this behind the `--raise-on-missing-docstrings` flag as it is currently implemented or just use it by default.