### PR TITLE
add pre-commit-hook file

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: darglint
+  name: darglint
+  description: "darglint: a functional docstring linter which checks whether a
+  docstring's' description matches the actual function/method implementation"
+  entry: darglint
+  language: python

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ would like a feature in *darglint*.
 - [Usage](#usage)
 - [Sphinx](#sphinx)
 - [Flake8](#flake8)
+- [Pre-commit](#Pre-commit)
 - [Roadmap](#roadmap)
 - [Contribution](#development-and-contributions)
 
@@ -341,6 +342,22 @@ Darglint will pull its configuration from any configuration file present.
 (So, if you would like to lint Sphinx-style comments, then you should have
 that setting enabled in a configuration file in the project directory.)
 
+## Pre-commit
+
+Download [pre-commit](https://pre-commit.com/) and
+[install](https://pre-commit.com/#install) it. Once it is installed, add this
+to `.pre-commit-config.yaml` in your repository:
+```yaml
+repos:
+-   repo: https://github.com/terrencepreilly/darglint
+    rev: master
+    hooks:
+    - id: darglint
+```
+Then run `pre-commit install` and you're ready to go. Before commiting,
+`darglint` will be run on the staged files. If it finds any errors, the user
+is notified and the commit is aborted. Store necessary configuration (such as
+error formatting) in `.darglint`, `config.cfg` or `tox.ini`.
 
 ## Roadmap
 The below list is the current roadmap for *darglint*.  For each

--- a/darglint/driver.py
+++ b/darglint/driver.py
@@ -197,7 +197,7 @@ def main():
     files = []
     for f in args.files:
         p = pathlib.Path(f)
-        if not p.is_dir():
+        if not p.is_dir() and p.suffix == '.py':
             files.append(f)
         # Convert back to strings to not require modifications of any
         # subsequent code.


### PR DESCRIPTION
This PR will make it possible to use darglint as a hook using [pre-commit](https://pre-commit.com). It might be useful for developers that want to use `darglint` to check for errors in docstrings before commiting the code.

I only did two changes:
- .pre-commit-hooks.yaml: added the file, which pre-commit will use
- README.md: updated the documentation

I tried to use the pre-commit hook on a personal project and it seem to work fine. It might be useful for other developers as well, hence the PR. :)