### PR TITLE
[RFC] Validating item definition format

### DIFF
--- a/darglint/errors.py
+++ b/darglint/errors.py
@@ -174,6 +174,52 @@ class MissingParameterError(DarglintError):
         )
 
 
+class DefinitionNotEndingWithPeriodError(DarglintError):
+    """Describes when a definition is not ending with a period."""
+
+    error_code = 'I?01'
+
+    def __init__(self, function, definition, line_numbers=None):
+         # type: (Union[ast.FunctionDef, ast.AsyncFunctionDef], str, Tuple[int, int]) -> None
+        """Instantiate the error's message.
+
+        Args:
+            function: An ast node for the function.
+            definition: The definition of the argument that is not ending with a period.
+            line_numbers: The line numbers where this error occurs.
+
+        """
+        self.general_message = "Definition not ending with a period"
+        self.terse_message = "p {}".format(definition)
+        super(DefinitionNotEndingWithPeriodError, self).__init__(
+            function,
+            line_numbers=line_numbers,
+        )
+
+
+class DefinitionNotStartingWithCapitalError(DarglintError):
+    """Describes when a definition is not starting with a capital."""
+
+    error_code = 'I?02'
+
+    def __init__(self, function, definition, line_numbers=None):
+          # type: (Union[ast.FunctionDef, ast.AsyncFunctionDef], str, Tuple[int, int]) -> None
+        """Instantiate the error's message.
+
+        Args:
+            function: An ast node for the function.
+            name: The definition of the argument that is not starting with a capital.
+            line_numbers: The line numbers where this error occurs.
+
+        """
+        self.general_message = 'Definition not starting with a capital'
+        self.terse_message = 'c {}'.format(definition)
+        super(DefinitionNotStartingWithCapitalError, self).__init__(
+            function,
+            line_numbers=line_numbers,
+        )
+
+
 class ExcessParameterError(DarglintError):
     """Describes when a docstring contains a parameter not in function."""
 

--- a/darglint/integrity_checker.py
+++ b/darglint/integrity_checker.py
@@ -40,6 +40,8 @@ from .errors import (  # noqa: F401
     MissingYieldError,
     ParameterTypeMismatchError,
     ReturnTypeMismatchError,
+    DefinitionNotStartingWithCapitalError,
+    DefinitionNotEndingWithPeriodError,
 )
 from .error_report import (
     ErrorReport,
@@ -295,6 +297,33 @@ class IntegrityChecker(object):
                     line_numbers=line_numbers,
                 )
             )
+
+        for definition in self.docstring.get_definitions(Sections.ARGUMENTS_SECTION) or []:
+            if not definition.endswith('.'):
+                line_numbers = self.docstring.get_line_numbers_for_value(
+                    NodeType.ARGS_SECTION,
+                    definition,
+                ) or default_line_numbers
+                self.errors.append(
+                    DefinitionNotEndingWithPeriodError(
+                        self.function.function,
+                        definition,
+                        line_numbers=line_numbers,
+                    )
+                )
+            if definition[0] != definition[0].upper():
+                line_numbers = self.docstring.get_line_numbers_for_value(
+                    NodeType.ARGS_SECTION,
+                    definition,
+                ) or default_line_numbers
+                self.errors.append(
+                    DefinitionNotStartingWithCapitalError(
+                        self.function.function,
+                        definition,
+                        line_numbers=line_numbers,
+                    )
+                )
+
 
     def _check_variables(self):
         # type: () -> None


### PR DESCRIPTION
Hi @terrencepreilly,

Although its not a formal rule in Google's styleguide, all examples have item definitions starting with a capital and ending with a period. Internally we have adopted this convention, and would love to have this automatically checked.

It not being a formal rule, and me not being familiar with the codebase, I thought it might be good to start with a minimal PR and get some feedback early on.

The current setup will break on Sphinx docs and can also be applied to return/yield/etc sections.

What are your thoughts on this? Would it be an interesting addition? Perhaps something that can be enabled via a flag?

*Update*

I realize that yields, returns and raises sections aren't converted to to ITEM_DEFINITIONS and therefore my setup for these sections doesn't work. To make this properly work I believe we should extend the EBNF. 