### PR TITLE
Add support for excluding functions by a regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ We can ignore multiple errors by using a comma-separated list:
 ignore=DAR402,DAR103
 ```
 
+Instead of specifying error codes to ignore in general one can also specify a
+regex to exclude certain function names from tests. For example, the following 
+configuration would disable linting on all private methods.
+```ini
+[darglint]
+ignore_regex=^_(.*)
+```
+
 ### Message Template Configuration
 
 If we would like to specify a message template, we may do so as

--- a/darglint/config.py
+++ b/darglint/config.py
@@ -102,6 +102,7 @@ def load_config_file(filename):  # type: (str) -> Configuration
     ignore = list()
     enable_disabled = list()
     message_template = None
+    ignore_regex = None
     style = DocstringStyle.GOOGLE
     strictness = Strictness.FULL_DESCRIPTION
     if 'darglint' in config.sections():
@@ -115,6 +116,8 @@ def load_config_file(filename):  # type: (str) -> Configuration
                 enable_disabled.append(error.strip())
         if 'message_template' in config['darglint']:
             message_template = config['darglint']['message_template']
+        if 'ignore_regex' in config['darglint']:
+            ignore_regex = config['darglint']['ignore_regex']
         if 'docstring_style' in config['darglint']:
             raw_style = config['darglint']['docstring_style'].lower().strip()
             if raw_style == 'google':
@@ -145,6 +148,7 @@ def load_config_file(filename):  # type: (str) -> Configuration
         message_template=message_template,
         style=style,
         strictness=strictness,
+        ignore_regex=ignore_regex
     )
 
 

--- a/darglint/config.py
+++ b/darglint/config.py
@@ -63,8 +63,9 @@ class Strictness(Enum):
 
 class Configuration(object):
 
-    def __init__(self, ignore, message_template, style, strictness, enable_disabled=[]):
-        # type: (List[str], Optional[str], DocstringStyle, Strictness) -> None
+    def __init__(self, ignore, message_template, style, strictness,
+                 ignore_regex=None, enable_disabled=[]):
+        # type: (List[str], Optional[str], DocstringStyle, Strictness, Optional[str]) -> None
         """Initialize the configuration object.
 
         Args:
@@ -72,6 +73,7 @@ class Configuration(object):
             message_template: the template with which to format the errors.
             style: The style of docstring.
             strictness: The minimum strictness to allow.
+            ignore_regex: A regular expression that allows to ignore objects by name
             enable_disabled: A list of of error codes that are disabled by default.
         """
         disabled = list(set(DEFAULT_DISABLED) - set(enable_disabled))
@@ -79,6 +81,7 @@ class Configuration(object):
         self.message_template = message_template
         self.style = style
         self.strictness = strictness
+        self.ignore_regex = ignore_regex
 
 
 def load_config_file(filename):  # type: (str) -> Configuration

--- a/darglint/integrity_checker.py
+++ b/darglint/integrity_checker.py
@@ -92,6 +92,12 @@ class IntegrityChecker(object):
         # type: (FunctionDescription) -> None
         if function.docstring is None:
             return
+        elif (
+            self.config.ignore_regex and
+            re.match(self.config.ignore_regex, function.name)
+        ):
+            return
+
         self.executor.submit(self.run_checks, function)
 
     def run_checks(self, function):

--- a/darglint/integrity_checker.py
+++ b/darglint/integrity_checker.py
@@ -133,6 +133,7 @@ class IntegrityChecker(object):
         self._sorted = False
 
     def _skip_checks(self, function):
+        # type: (FunctionDescription) -> bool
         no_docsting = function.docstring is None
         skip_by_regex = (
             self.config.ignore_regex and

--- a/tests/test_integrity_checker.py
+++ b/tests/test_integrity_checker.py
@@ -142,8 +142,8 @@ class IntegrityCheckerTestCase(TestCase):
                 ignore_regex=r'^_(.*)'
             )
         )
-        checker.schedule(functions[0])
-        checker.schedule(functions[1])
+        checker.run_checks(functions[0])
+        checker.run_checks(functions[1])
 
         errors = checker.errors
         self.assertEqual(len(errors), 1)

--- a/tests/test_integrity_checker.py
+++ b/tests/test_integrity_checker.py
@@ -121,6 +121,33 @@ class IntegrityCheckerSphinxTestCase(TestCase):
 
 class IntegrityCheckerTestCase(TestCase):
 
+    def test_ignore_private_methods(self):
+        program = '\n'.join([
+            'def function_with_missing_parameter(x):',
+            '    """We\'re missing a description of x."""',
+            '    print(x / 2)',
+            ''
+            'def _same_error_but_private_method(x):',
+            '    """We\'re missing a description of x."""',
+            '    print(x / 2)',
+        ])
+        tree = ast.parse(program)
+        functions = get_function_descriptions(tree)
+        checker = IntegrityChecker(
+            config=Configuration(
+                ignore=[],
+                message_template=None,
+                style=DocstringStyle.GOOGLE,
+                strictness=Strictness.FULL_DESCRIPTION,
+                ignore_regex=r'^_(.*)'
+            )
+        )
+        checker.schedule(functions[0])
+        checker.schedule(functions[1])
+
+        errors = checker.errors
+        self.assertEqual(len(errors), 1)
+
     def test_missing_parameter_added(self):
         program = '\n'.join([
             'def function_with_missing_parameter(x):',


### PR DESCRIPTION
This PR adds support for excluding certain functions from validation based on a regular expression given in the configuration. A special case of this might be ignoring private methods, hence this closes #22.