### PR TITLE
only run pre-commit hook on python files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,3 +4,4 @@
   docstring's' description matches the actual function/method implementation"
   entry: darglint
   language: python
+  types: [python]


### PR DESCRIPTION
This prevents `pre-commit` from running `darglint` on each file that gets
committed, but restricts it to just python files, which increases
performance in case no python files are being committed (or only a subset
of staged files are in fact python files).

This is a follow-up to #43.