### PR TITLE
Document how to install dependencies in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,13 @@ source .env/bin/activate
 pip install -e .
 ```
 
+You can install dependencies using
+
+```bash
+pip install poetry
+poetry install
+```
+
 You can run the tests using
 
 ```bash


### PR DESCRIPTION
Hi,
I tried to run the tests following the contribution documentation. I had an issues saying that flake8 is missing.
It was because the dev dependencies were not installed. So I added in the readme how to install them using poetry.

Maybe an other solution would be to document how to install them using tox, like it is done by travis.