### PR TITLE
Sections.VARIABLES_SECTION is not supported by numpy docstrings

### DIFF
--- a/darglint/docstring/google.py
+++ b/darglint/docstring/google.py
@@ -91,6 +91,16 @@ class _CykVisitor(object):
 class Docstring(BaseDocstring):
     """The docstring class interprets the AST of a docstring."""
 
+    _supported_sections = (
+        Sections.SHORT_DESCRIPTION,
+        Sections.LONG_DESCRIPTION,
+        Sections.ARGUMENTS_SECTION,
+        Sections.RAISES_SECTION,
+        Sections.YIELDS_SECTION,
+        Sections.RETURNS_SECTION,
+        Sections.NOQAS,
+    )  # type: Tuple[Sections, ...]
+
     def __init__(self, root, style=DocstringStyle.GOOGLE):
         # type: (Union[CykNode, str], DocstringStyle) -> None
         """Create a new docstring from the AST.
@@ -414,16 +424,7 @@ class Docstring(BaseDocstring):
 
         """
         sections = {
-            section for section in Sections
-            for section in {
-                Sections.SHORT_DESCRIPTION,
-                Sections.LONG_DESCRIPTION,
-                Sections.ARGUMENTS_SECTION,
-                Sections.RAISES_SECTION,
-                Sections.YIELDS_SECTION,
-                Sections.RETURNS_SECTION,
-                Sections.NOQAS,
-            }
+            section for section in self._supported_sections
             if self.get_section(section)
         }
         if strictness == Strictness.SHORT_DESCRIPTION:

--- a/darglint/docstring/numpy.py
+++ b/darglint/docstring/numpy.py
@@ -1,8 +1,8 @@
 """Contains a subclass of `Docstring`, which is for numpy.
 
-TODO: Consider refactoring docstring's discover method so that it 
-builds up a tree of identifiers, rather than a dictionary.  That is, 
-if it's proven more efficient or is much cleaner. 
+TODO: Consider refactoring docstring's discover method so that it
+builds up a tree of identifiers, rather than a dictionary.  That is,
+if it's proven more efficient or is much cleaner.
 
 """
 import copy
@@ -55,6 +55,15 @@ from ..custom_assert import (
 
 
 class Docstring(BaseDocstring):
+    _supported_sections = (
+        Sections.SHORT_DESCRIPTION,
+        Sections.LONG_DESCRIPTION,
+        Sections.ARGUMENTS_SECTION,
+        Sections.RAISES_SECTION,
+        Sections.YIELDS_SECTION,
+        Sections.RETURNS_SECTION,
+        Sections.NOQAS,
+    )  # type: Tuple[Sections, ...]
 
     def __init__(self, root, style=DocstringStyle.SPHINX):
         # type: (Union[CykNode, str], DocstringStyle) -> None  # noqa: E501
@@ -351,7 +360,7 @@ class Docstring(BaseDocstring):
 
         """
         sections = {
-            section for section in Sections
+            section for section in self._supported_sections
             if self.get_section(section)
         }
         if strictness == Strictness.SHORT_DESCRIPTION:

--- a/tests/test_docstring.py
+++ b/tests/test_docstring.py
@@ -13,6 +13,7 @@ from random import (
     shuffle,
 )
 
+from darglint.config import Strictness
 from darglint.docstring.base import Sections
 from darglint.docstring.docstring import Docstring
 
@@ -939,3 +940,128 @@ class DocstringForNumpyTest(TestCase):
             docstring.get_items(Sections.ARGUMENTS_SECTION),
             ['x', 'y', 'z'],
         )
+
+    def test_satisfies_strictness_short_description(self):
+        parameters = [
+            (None, False),
+            ('', False),
+            ('Dostring with just title.', True),
+            (
+                '\n'.join([
+                    'Dostring with title and parameters.',
+                    '',
+                    'Parameters',
+                    '----------',
+                    'x: int',
+                    '    The first parameter.',
+                    '',
+                    'y: Optional[int]',
+                    '    The second parameter.',
+                    '',
+                ]),
+                False,
+            ),
+            (
+                '\n'.join([
+                    'Dostring with only long,',
+                    'long, really long description.',
+                    '',
+                ]),
+                False,
+            ),
+        ]
+        for raw_docstring, is_strictness_satisfied in parameters:
+            docstring = Docstring.from_numpy(raw_docstring)
+            with self.subTest(raw_docstring):
+                self.assertIs(
+                    docstring.satisfies_strictness(
+                        Strictness.SHORT_DESCRIPTION,
+                    ),
+                    is_strictness_satisfied,
+                    msg=raw_docstring,
+                )
+
+    def test_satisfies_strictness_long_description(self):
+        parameters = [
+            (None, False),
+            ('', False),
+            ('Dostring with just title.', True),
+            (
+                '\n'.join([
+                    'Dostring with title, long description and parameters.',
+                    '',
+                    'Long description goes here.',
+                    '',
+                    'Parameters',
+                    '----------',
+                    'x: int',
+                    '    The only parameter.',
+                    '',
+                ]),
+                False,
+            ),
+            (
+                '\n'.join([
+                    '',
+                    'Dostring with only long,',
+                    'long, really long description.',
+                    '',
+                    '',
+                ]),
+                True,
+            ),
+        ]
+        for raw_docstring, is_strictness_satisfied in parameters:
+            docstring = Docstring.from_numpy(raw_docstring)
+            with self.subTest(raw_docstring):
+                self.assertIs(
+                    docstring.satisfies_strictness(
+                        Strictness.LONG_DESCRIPTION,
+                    ),
+                    is_strictness_satisfied,
+                    msg=raw_docstring,
+                )
+
+    def test_satisfies_strictness_full_description(self):
+        parameters = [
+            (None, False),
+            ('', False),
+            ('Dostring with just title.', False),
+            (
+                '\n'.join([
+                    'Dostring with title, long description and parameters.',
+                    '',
+                    'Long description goes here.',
+                    '',
+                    'Parameters',
+                    '----------',
+                    'x: int',
+                    '    The only parameter.',
+                    '',
+                    'Returns',
+                    '-------',
+                    'int',
+                    '    Magic, random number.',
+                    '',
+                ]),
+                False,
+            ),
+            (
+                '\n'.join([
+                    'Dostring with only long,',
+                    'long, really long description.',
+                    '',
+                ]),
+                False,
+            ),
+        ]
+        for raw_docstring, is_strictness_satisfied in parameters:
+            docstring = Docstring.from_numpy(raw_docstring)
+            with self.subTest(raw_docstring):
+                self.assertIs(
+                    docstring.satisfies_strictness(
+                        Strictness.FULL_DESCRIPTION,
+                    ),
+                    is_strictness_satisfied,
+                    msg=raw_docstring,
+                )


### PR DESCRIPTION
This PR do few things related to `Sections` and docstring `.get_section()`:

+ refactor list comprehension in google docstring `satisfies_strictness`
+ add some tests of numpy `Docstring.satisfies_strictness()`
+ removes `Sections.VARIABLES_SECTION` from supported sections of numpy docstring

Closes #133 