### PR TITLE
move some enums to individual modules

### DIFF
--- a/darglint/config.py
+++ b/darglint/config.py
@@ -22,6 +22,7 @@ from typing import (  # noqa
 )
 
 from .docstring.base import DocstringStyle
+from .strictness import Strictness
 
 
 def get_logger():  # type: () -> Logger
@@ -41,50 +42,6 @@ POSSIBLE_CONFIG_FILENAMES = (
 )
 
 DEFAULT_DISABLED = {'DAR104'}
-
-
-class Strictness(Enum):
-    """The minimum strictness with which to apply checks.
-
-    Strictness does not describe whether or not a check
-    should be applied. Rather, if a check is done, strictness
-    describes how intense/strict/deep the check should be.
-
-    Each level here describes what is required of the
-    docstring at the given level of strictness.  For example,
-    SHORT_DESCRIPTION describes the situation where one-liners are
-    allowed, and sections are not required.
-
-    If the docstring being checked contains more than the
-    allowed amount below, then it is assumed that everything
-    must be checked.
-
-    """
-
-    # Allow a single-line description.
-    SHORT_DESCRIPTION = 1
-
-    # Allow a single-line description followed by a long
-    # description, but no sections.
-    LONG_DESCRIPTION = 2
-
-    # Require everything.
-    FULL_DESCRIPTION = 3
-
-    @classmethod
-    def from_string(cls, strictness):
-        strictness = strictness.lower().strip()
-        if strictness in {'short_description', 'short'}:
-            return cls.SHORT_DESCRIPTION
-        if strictness in {'long_description', 'long'}:
-            return cls.LONG_DESCRIPTION
-        if strictness in {'full_description', 'full'}:
-            return cls.FULL_DESCRIPTION
-
-        raise Exception(
-            'Unrecognized strictness amount "{}".  '.format(strictness) +
-            'Should be one of {"short", "long", "full"}'
-        )
 
 
 class AssertStyle(Enum):
@@ -133,7 +90,7 @@ class Configuration(object):
     def __init__(self, ignore, message_template, style, strictness,
                  ignore_regex=None, enable=[], indentation=4,
                  assert_style=AssertStyle.LOG, log_level=LogLevel.CRITICAL):
-        # type: (List[str], Optional[str], DocstringStyle, Strictness, Optional[str], List[str], int, AssertStyle) -> None  # noqa: E501
+        # type: (List[str], Optional[str], DocstringStyle, Strictness, Optional[str], List[str], int, AssertStyle, LogLevel) -> None  # noqa: E501
         """Initialize the configuration object.
 
         Args:

--- a/darglint/config.py
+++ b/darglint/config.py
@@ -21,7 +21,7 @@ from typing import (  # noqa
     Optional,
 )
 
-from .docstring.base import DocstringStyle
+from .docstring.style import DocstringStyle
 from .strictness import Strictness
 
 

--- a/darglint/docstring/base.py
+++ b/darglint/docstring/base.py
@@ -10,6 +10,8 @@ from typing import (
     Iterable,
 )
 
+from ..strictness import Strictness
+
 
 class DocstringStyle(enum.Enum):
     GOOGLE = 0
@@ -160,8 +162,7 @@ class BaseDocstring(ABC):
 
     @abstractmethod
     def satisfies_strictness(self, strictness):
-        # NOTE: We can't add the type signature because adding Strictness
-        # to the imports would cause a circular dependency.
+        # type(Strictness) -> bool
         """Return true if the docstring has no more than the min strictness.
 
         Args:

--- a/darglint/docstring/base.py
+++ b/darglint/docstring/base.py
@@ -13,29 +13,6 @@ from typing import (
 from ..strictness import Strictness
 
 
-class DocstringStyle(enum.Enum):
-    GOOGLE = 0
-    SPHINX = 1
-    NUMPY = 2
-
-    @classmethod
-    def from_string(cls, style):
-        style = style.lower().strip()
-        if style == 'google':
-            return cls.GOOGLE
-        if style == 'sphinx':
-            return cls.SPHINX
-        if style == 'numpy':
-            return cls.NUMPY
-
-        raise Exception(
-                'Unrecognized style "{}".  Should be one of {}'.format(
-                    style,
-                    [x.name for x in DocstringStyle]
-                )
-            )
-
-
 class Sections(enum.Enum):
     SHORT_DESCRIPTION = 0
     LONG_DESCRIPTION = 1

--- a/darglint/docstring/base.py
+++ b/darglint/docstring/base.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-import enum
 from typing import (
     Callable,
     Dict,
@@ -10,18 +9,8 @@ from typing import (
     Iterable,
 )
 
-from ..strictness import Strictness
-
-
-class Sections(enum.Enum):
-    SHORT_DESCRIPTION = 0
-    LONG_DESCRIPTION = 1
-    ARGUMENTS_SECTION = 2
-    RAISES_SECTION = 4
-    YIELDS_SECTION = 6
-    RETURNS_SECTION = 8
-    VARIABLES_SECTION = 10
-    NOQAS = 13
+from .sections import Sections  # noqa: F401
+from ..strictness import Strictness  # noqa: F401
 
 
 class BaseDocstring(ABC):

--- a/darglint/docstring/google.py
+++ b/darglint/docstring/google.py
@@ -18,9 +18,9 @@ from ..custom_assert import (
 )
 from .base import (  # noqa: F401
     BaseDocstring,
-    DocstringStyle,
     Sections,
 )
+from .style import DocstringStyle
 from ..node import (
     CykNode,
 )

--- a/darglint/docstring/google.py
+++ b/darglint/docstring/google.py
@@ -34,9 +34,7 @@ from ..lex import (
 from ..errors import (
     DarglintError,
 )
-from ..config import (
-    Strictness,
-)
+from ..strictness import Strictness
 from ..parse.identifiers import (
     ArgumentIdentifier,
     ArgumentItemIdentifier,

--- a/darglint/docstring/google.py
+++ b/darglint/docstring/google.py
@@ -16,10 +16,8 @@ from typing import (  # noqa: F401
 from ..custom_assert import (
     Assert,
 )
-from .base import (  # noqa: F401
-    BaseDocstring,
-    Sections,
-)
+from .base import BaseDocstring
+from .sections import Sections
 from .style import DocstringStyle
 from ..node import (
     CykNode,

--- a/darglint/docstring/numpy.py
+++ b/darglint/docstring/numpy.py
@@ -36,9 +36,7 @@ from .base import (
 from ..node import (
     CykNode,
 )
-from ..config import (
-    Strictness,
-)
+from ..strictness import Strictness
 from ..parse.numpy import (
     parse,
 )

--- a/darglint/docstring/numpy.py
+++ b/darglint/docstring/numpy.py
@@ -28,10 +28,8 @@ from ..parse.identifiers import (
     Identifier,
     NoqaIdentifier,
 )
-from .base import (
-    BaseDocstring,
-    Sections,
-)
+from .base import BaseDocstring
+from .sections import Sections
 from .style import DocstringStyle
 from ..node import (
     CykNode,

--- a/darglint/docstring/numpy.py
+++ b/darglint/docstring/numpy.py
@@ -30,9 +30,9 @@ from ..parse.identifiers import (
 )
 from .base import (
     BaseDocstring,
-    DocstringStyle,
     Sections,
 )
+from .style import DocstringStyle
 from ..node import (
     CykNode,
 )

--- a/darglint/docstring/sections.py
+++ b/darglint/docstring/sections.py
@@ -1,0 +1,13 @@
+import enum
+
+
+class Sections(enum.Enum):
+    SHORT_DESCRIPTION = 0
+    LONG_DESCRIPTION = 1
+    ARGUMENTS_SECTION = 2
+    RAISES_SECTION = 4
+    YIELDS_SECTION = 6
+    RETURNS_SECTION = 8
+    VARIABLES_SECTION = 10
+    NOQAS = 13
+

--- a/darglint/docstring/sphinx.py
+++ b/darglint/docstring/sphinx.py
@@ -12,9 +12,9 @@ from typing import (  # noqa
 
 from .base import (
     BaseDocstring,
-    DocstringStyle,
     Sections,
 )
+from .style import DocstringStyle
 from ..custom_assert import Assert
 from ..node import (
     CykNode,

--- a/darglint/docstring/sphinx.py
+++ b/darglint/docstring/sphinx.py
@@ -10,10 +10,8 @@ from typing import (  # noqa
     Union,
 )
 
-from .base import (
-    BaseDocstring,
-    Sections,
-)
+from .base import BaseDocstring
+from .sections import Sections
 from .style import DocstringStyle
 from ..custom_assert import Assert
 from ..node import (

--- a/darglint/docstring/sphinx.py
+++ b/darglint/docstring/sphinx.py
@@ -30,9 +30,7 @@ from ..lex import (
     lex,
     condense,
 )
-from ..config import (
-    Strictness,
-)
+from ..strictness import Strictness
 from ..errors import (
     DarglintError,
 )

--- a/darglint/docstring/style.py
+++ b/darglint/docstring/style.py
@@ -1,0 +1,24 @@
+import enum
+
+
+class DocstringStyle(enum.Enum):
+    GOOGLE = 0
+    SPHINX = 1
+    NUMPY = 2
+
+    @classmethod
+    def from_string(cls, style):
+        style = style.lower().strip()
+        if style == 'google':
+            return cls.GOOGLE
+        if style == 'sphinx':
+            return cls.SPHINX
+        if style == 'numpy':
+            return cls.NUMPY
+
+        raise Exception(
+                'Unrecognized style "{}".  Should be one of {}'.format(
+                    style,
+                    [x.name for x in DocstringStyle]
+                )
+            )

--- a/darglint/driver.py
+++ b/darglint/driver.py
@@ -19,7 +19,7 @@ from .config import (
     get_logger,
     LogLevel,
 )
-from .docstring.base import DocstringStyle
+from .docstring.style import DocstringStyle
 from .strictness import Strictness
 import darglint.errors
 from darglint.error_report import ErrorReport

--- a/darglint/driver.py
+++ b/darglint/driver.py
@@ -18,9 +18,9 @@ from .config import (
     get_config,
     get_logger,
     LogLevel,
-    Strictness,
 )
 from .docstring.base import DocstringStyle
+from .strictness import Strictness
 import darglint.errors
 from darglint.error_report import ErrorReport
 

--- a/darglint/flake8_entry.py
+++ b/darglint/flake8_entry.py
@@ -6,7 +6,7 @@ from typing import (  # noqa
     Tuple,
 )
 
-from .docstring.base import DocstringStyle
+from .docstring.style import DocstringStyle
 from .function_description import (
     get_function_descriptions,
 )

--- a/darglint/flake8_entry.py
+++ b/darglint/flake8_entry.py
@@ -14,8 +14,8 @@ from .integrity_checker import IntegrityChecker
 from .config import (
     Configuration,
     get_config,
-    Strictness,
 )
+from .strictness import Strictness
 
 
 __version__ = '1.5.5'

--- a/darglint/integrity_checker.py
+++ b/darglint/integrity_checker.py
@@ -40,10 +40,8 @@ from .errors import (  # noqa: F401
 from .error_report import (
     ErrorReport,
 )
-from .config import (
-    get_config,
-    Strictness,
-)
+from .config import get_config
+from .strictness import Strictness
 
 
 SYNTAX_NOQA = re.compile(r'#\s*noqa:\sS001')

--- a/darglint/integrity_checker.py
+++ b/darglint/integrity_checker.py
@@ -12,13 +12,9 @@ from typing import (  # noqa: F401
 from .function_description import (  # noqa: F401
     FunctionDescription,
 )
-from .docstring.base import (
-    BaseDocstring,
-    Sections,
-)
-from .docstring.docstring import (
-    Docstring,
-)
+from .docstring.base import BaseDocstring
+from .docstring.docstring import Docstring
+from .docstring.sections import Sections
 from .docstring.style import DocstringStyle
 from .errors import (  # noqa: F401
     DarglintError,

--- a/darglint/integrity_checker.py
+++ b/darglint/integrity_checker.py
@@ -12,16 +12,14 @@ from typing import (  # noqa: F401
 from .function_description import (  # noqa: F401
     FunctionDescription,
 )
-from .docstring.base import (  # noqa: F401
-    BaseDocstring,
-    DocstringStyle,
-)
 from .docstring.base import (
+    BaseDocstring,
     Sections,
 )
 from .docstring.docstring import (
     Docstring,
 )
+from .docstring.style import DocstringStyle
 from .errors import (  # noqa: F401
     DarglintError,
     ExcessParameterError,

--- a/darglint/strictness.py
+++ b/darglint/strictness.py
@@ -1,0 +1,45 @@
+from enum import Enum
+
+
+class Strictness(Enum):
+    """The minimum strictness with which to apply checks.
+
+    Strictness does not describe whether or not a check
+    should be applied. Rather, if a check is done, strictness
+    describes how intense/strict/deep the check should be.
+
+    Each level here describes what is required of the
+    docstring at the given level of strictness.  For example,
+    SHORT_DESCRIPTION describes the situation where one-liners are
+    allowed, and sections are not required.
+
+    If the docstring being checked contains more than the
+    allowed amount below, then it is assumed that everything
+    must be checked.
+
+    """
+
+    # Allow a single-line description.
+    SHORT_DESCRIPTION = 1
+
+    # Allow a single-line description followed by a long
+    # description, but no sections.
+    LONG_DESCRIPTION = 2
+
+    # Require everything.
+    FULL_DESCRIPTION = 3
+
+    @classmethod
+    def from_string(cls, strictness):
+        strictness = strictness.lower().strip()
+        if strictness in {'short_description', 'short'}:
+            return cls.SHORT_DESCRIPTION
+        if strictness in {'long_description', 'long'}:
+            return cls.LONG_DESCRIPTION
+        if strictness in {'full_description', 'full'}:
+            return cls.FULL_DESCRIPTION
+
+        raise Exception(
+            'Unrecognized strictness amount "{}".  '.format(strictness) +
+            'Should be one of {"short", "long", "full"}'
+        )

--- a/integration_tests/goldens.py
+++ b/integration_tests/goldens.py
@@ -14,7 +14,7 @@ from unittest import ( # noqa
 from darglint.docstring.docstring import (
     Docstring,
 )
-from darglint.docstring.base import (
+from darglint.docstring.sections import (
     Sections,
 )
 

--- a/integration_tests/test_flake8.py
+++ b/integration_tests/test_flake8.py
@@ -2,12 +2,10 @@ from unittest import TestCase
 
 from flake8.options.manager import OptionManager
 
-from darglint.config import (
-    get_config,
-    Strictness,
-)
-from darglint.docstring.base import DocstringStyle
+from darglint.config import get_config
+from darglint.docstring.style import DocstringStyle
 from darglint.flake8_entry import DarglintChecker
+from darglint.strictness import Strictness
 
 class Flake8TestCase(TestCase):
     """Tests that flake8 config is parsed correctly."""

--- a/tests/test_docstring.py
+++ b/tests/test_docstring.py
@@ -14,7 +14,7 @@ from random import (
 )
 
 from darglint.strictness import Strictness
-from darglint.docstring.base import Sections
+from darglint.docstring.sections import Sections
 from darglint.docstring.docstring import Docstring
 
 

--- a/tests/test_docstring.py
+++ b/tests/test_docstring.py
@@ -13,7 +13,7 @@ from random import (
     shuffle,
 )
 
-from darglint.config import Strictness
+from darglint.strictness import Strictness
 from darglint.docstring.base import Sections
 from darglint.docstring.docstring import Docstring
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -6,7 +6,7 @@ from unittest import (
 
 from darglint.function_description import get_function_descriptions
 from darglint.integrity_checker import IntegrityChecker
-from darglint.docstring.base import DocstringStyle
+from darglint.docstring.style import DocstringStyle
 from darglint.strictness import Strictness
 from darglint.utils import (
     ConfigurationContext,

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -7,9 +7,7 @@ from unittest import (
 from darglint.function_description import get_function_descriptions
 from darglint.integrity_checker import IntegrityChecker
 from darglint.docstring.base import DocstringStyle
-from darglint.config import (
-    Strictness,
-)
+from darglint.strictness import Strictness
 from darglint.utils import (
     ConfigurationContext,
 )

--- a/tests/test_integrity_checker.py
+++ b/tests/test_integrity_checker.py
@@ -4,9 +4,7 @@ from unittest import (
     skip,
 )
 
-from darglint.config import (
-    Strictness,
-)
+from darglint.strictness import Strictness
 from darglint.docstring.base import (
     DocstringStyle,
 )

--- a/tests/test_integrity_checker.py
+++ b/tests/test_integrity_checker.py
@@ -5,9 +5,7 @@ from unittest import (
 )
 
 from darglint.strictness import Strictness
-from darglint.docstring.base import (
-    DocstringStyle,
-)
+from darglint.docstring.style import DocstringStyle
 from darglint.integrity_checker import (
     IntegrityChecker,
 )

--- a/tests/test_numpy_parser.py
+++ b/tests/test_numpy_parser.py
@@ -7,9 +7,7 @@ from unittest import (
 from darglint.docstring.base import (
     DocstringStyle,
 )
-from darglint.config import (
-    Strictness,
-)
+from darglint.strictness import Strictness
 from darglint.lex import (
     condense,
     lex,

--- a/tests/test_numpy_parser.py
+++ b/tests/test_numpy_parser.py
@@ -4,9 +4,7 @@ from unittest import (
     TestCase,
     skip,
 )
-from darglint.docstring.base import (
-    DocstringStyle,
-)
+from darglint.docstring.style import DocstringStyle
 from darglint.strictness import Strictness
 from darglint.lex import (
     condense,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,10 +23,8 @@ from darglint.utils import (
     ConfigurationContext,
     CykNodeUtils,
 )
-from darglint.config import (
-    DocstringStyle,
-    Strictness,
-)
+from darglint.config import DocstringStyle
+from darglint.strictness import Strictness
 
 
 class DocstringTestCase(TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -23,7 +23,7 @@ from darglint.utils import (
     ConfigurationContext,
     CykNodeUtils,
 )
-from darglint.config import DocstringStyle
+from darglint.docstring.style import DocstringStyle
 from darglint.strictness import Strictness
 
 


### PR DESCRIPTION
This PR is the first part of the refactoring discussed in #135 

I decided to leave `LogLevel`, `Assert` in `darglint.config`, and `BaseTokenType` in `darglint.token` because they are used almost only by the module they are defined, however, if you wish I could move them to dedicated, individual modules.

I can add more commits with `satisfies_strictness` refactoring to this branch or create a new one when this PR will be merged, so please let me know which way you prefer :smile: 