### PR TITLE
Load 'enable' option correctly from the config file

### DIFF
--- a/darglint/config.py
+++ b/darglint/config.py
@@ -215,7 +215,7 @@ def load_config_file(filename):  # type: (str) -> Configuration
             errors = config['darglint']['ignore']
             for error in errors.split(','):
                 ignore.append(error.strip())
-        if 'enable' in config.sections():
+        if 'enable' in config['darglint']:
             to_enable = config['darglint']['enable']
             for error in to_enable.split(','):
                 enable.append(error.strip())


### PR DESCRIPTION
The `enable` option of a configuration file isn't loaded. Darglint works as expected if the setting is passed as a command line argument.

To reproduce the problem, lint the file `integration_tests/files/missing_arg_type.py` with the following configuration file:

```ini
[darglint]
enable=DAR104
```

It doesn't raise a `DAR104` error as we'd expect.

This is a simple fix so I felt that opening an issue for it was unneeded.