### PR TITLE
Add ignore_raise parameter to ignore common exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ Finally, the configuration file must be located either in the directory
 directory.
 
 Currently, the configuration file allows us to ignore errors, to specify
-message templates, and to specify the strictness of checks.
+message templates, to specify the strictness of checks and to ignore common
+exceptions.
 
 ### Error Configuration
 
@@ -158,6 +159,16 @@ strictness=short
 ```
 
 In your configuration file.
+
+### Ignoring common exceptions
+
+We can specify a list of exceptions that don't need to be documented in the
+raises section of a docstring. For example,
+
+```ini
+[darglint]
+ignore_raise=ValueError,MyCustomError
+```
 
 ### Logging
 

--- a/darglint/config.py
+++ b/darglint/config.py
@@ -88,9 +88,9 @@ class LogLevel(Enum):
 class Configuration(object):
 
     def __init__(self, ignore, message_template, style, strictness,
-                 ignore_regex=None, enable=[], indentation=4,
+                 ignore_regex=None, ignore_raise=[], enable=[], indentation=4,
                  assert_style=AssertStyle.LOG, log_level=LogLevel.CRITICAL):
-        # type: (List[str], Optional[str], DocstringStyle, Strictness, Optional[str], List[str], int, AssertStyle, LogLevel) -> None  # noqa: E501
+        # type: (List[str], Optional[str], DocstringStyle, Strictness, Optional[str], List[str], List[str], int, AssertStyle, LogLevel) -> None  # noqa: E501
         """Initialize the configuration object.
 
         Args:
@@ -100,6 +100,8 @@ class Configuration(object):
             strictness: The minimum strictness to allow.
             ignore_regex: A regular expression which enables ignoring
                 functions/methods by name.
+            ignore_raise: A list of exceptions that don't need to be
+                documented.
             enable: A list of of error codes that are disabled by default.
             indentation: The number of spaces to count as an indent.
             assert_style: The assert style to use (e.g. log on failed
@@ -113,6 +115,7 @@ class Configuration(object):
         self.strictness = strictness
         self.errors_to_ignore = self._get_errors_to_ignore()
         self.ignore_regex = ignore_regex
+        self.ignore_raise = ignore_raise
         self.indentation = indentation
         self.assert_style = assert_style
         self.log_level = log_level
@@ -138,6 +141,7 @@ class Configuration(object):
             'indentation={indentation}',
             'ignore={errors_to_ignore}',
             'ignore_regex={ignore_regex}',
+            'ignore_raise={ignore_raise}',
         ]).format(**self.__dict__)
 
     @classmethod
@@ -206,6 +210,7 @@ def load_config_file(filename):  # type: (str) -> Configuration
     enable = list()
     message_template = None
     ignore_regex = None
+    ignore_raise = list()
     style = DocstringStyle.GOOGLE
     strictness = Strictness.FULL_DESCRIPTION
     indentation = 4
@@ -223,6 +228,10 @@ def load_config_file(filename):  # type: (str) -> Configuration
             message_template = config['darglint']['message_template']
         if 'ignore_regex' in config['darglint']:
             ignore_regex = config['darglint']['ignore_regex']
+        if 'ignore_raise' in config['darglint']:
+            to_ignore_raise = config['darglint']['ignore_raise']
+            for exception in to_ignore_raise.split(','):
+                ignore_raise.append(exception.strip())
         if 'docstring_style' in config['darglint']:
             raw_style = config['darglint']['docstring_style']
             style = DocstringStyle.from_string(raw_style)
@@ -250,6 +259,7 @@ def load_config_file(filename):  # type: (str) -> Configuration
         style=style,
         strictness=strictness,
         ignore_regex=ignore_regex,
+        ignore_raise=ignore_raise,
         enable=enable,
         indentation=indentation,
     )

--- a/darglint/driver.py
+++ b/darglint/driver.py
@@ -51,6 +51,15 @@ parser.add_argument(
     ),
 )
 parser.add_argument(
+    '--ignore-raise',
+    '-ir',
+    type=str,
+    help=(
+        'Exceptions that don\'t need to be documented in docstrings. '
+        'Accepts a comma-separated list. E.g.: "ValueError,MyCustomError"'
+    ),
+)
+parser.add_argument(
     '--raise-syntax',
     action='store_true',
     help=(
@@ -288,6 +297,10 @@ def main():
 
         if args.ignore_regex:
             config.ignore_regex = args.ignore_regex
+        if args.ignore_raise:
+            config.ignore_raise = [
+                x.strip() for x in args.ignore_raise.split(",")
+            ]
 
         raise_errors_for_syntax = args.raise_syntax or False
         for filename in files:

--- a/darglint/driver.py
+++ b/darglint/driver.py
@@ -52,7 +52,7 @@ parser.add_argument(
 )
 parser.add_argument(
     '--ignore-raise',
-    '-ir',
+    '-c',
     type=str,
     help=(
         'Exceptions that don\'t need to be documented in docstrings. '

--- a/darglint/integrity_checker.py
+++ b/darglint/integrity_checker.py
@@ -438,7 +438,8 @@ class IntegrityChecker(object):
         exception_types = docstring.get_items(Sections.RAISES_SECTION)
         docstring_raises = set(exception_types or [])
         actual_raises = function.raises
-        missing_in_doc = actual_raises - docstring_raises
+        ignore_raise = set(self.config.ignore_raise)
+        missing_in_doc = actual_raises - docstring_raises - ignore_raise
 
         missing_in_doc = self._remove_ignored(
             docstring,

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -338,3 +338,25 @@ class ErrorTest(TestCase):
             len(errors),
             1,
         )
+
+    def test_ignore_raise(self):
+        ignore_raise_config = {
+            'ignore_raise': ['ValueError']
+        }
+        src = '\n'.join([
+            'def undocumented_exception():',
+            '    """Make sure ignore_raise works correctly."""',
+            '    raise ValueError',
+        ])
+
+        errors = self.get_n_errors(1, src)
+        self.assertEqual(
+            len(errors),
+            1,
+        )
+
+        errors = self.get_n_errors(0, src, ignore_raise_config)
+        self.assertEqual(
+            len(errors),
+            0,
+        )


### PR DESCRIPTION
Closes #144.

Exceptions listed in `ignore_raise` don't need to be listed in the `Raises` section of a docstring.
Of course, if an user explicitly chooses to include an ignored exception in a docstring, other correlated errors such as `ExcessRaiseError` can still apply.