### PR TITLE
Add skip property

### DIFF
--- a/darglint/analysis/function_and_method_visitor.py
+++ b/darglint/analysis/function_and_method_visitor.py
@@ -10,16 +10,22 @@ class FunctionAndMethodVisitor(ast.NodeVisitor):
         # type: () -> None
         self.callables = set()  # type: Set[ast.FunctionDef, ast.AsyncFunctionDef]
         self._methods = set()  # type: Set[ast.FunctionDef, ast.AsyncFunctionDef]
+        self._properties = set()  # type: Set[ast.FunctionDef, ast.AsyncFunctionDef]
 
     @property
     def functions(self):
         # type: () -> Union[ast.FunctionDef, ast.AsyncFunctionDef]
-        return list(self.callables - self._methods)
+        return list(self.callables - self._methods - self._properties)
 
     @property
     def methods(self):
         # type: () -> Union[ast.FunctionDef, ast.AsyncFunctionDef]
         return list(self._methods)
+
+    @property
+    def properties(self):
+        # type: () -> Union[ast.FunctionDef, ast.AsyncFunctionDef]
+        return list(self._properties)
 
     def visit_ClassDef(self, node):
         # type: (ast.ClassDef) -> ast.AST
@@ -27,7 +33,10 @@ class FunctionAndMethodVisitor(ast.NodeVisitor):
             if isinstance(item, ast.FunctionDef) or isinstance(
                 item, ast.AsyncFunctionDef
             ):
-                self._methods.add(item)
+                if self._has_property_decorator(item):
+                    self._properties.add(item)
+                else:
+                    self._methods.add(item)
         return self.generic_visit(node)
 
     def visit_FunctionDef(self, node):
@@ -39,3 +48,10 @@ class FunctionAndMethodVisitor(ast.NodeVisitor):
         # type: (ast.AsyncFunctionDef) -> ast.AST
         self.callables.add(node)
         return self.generic_visit(node)
+
+    def _has_property_decorator(self, node):
+        # type: (Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> bool
+        for decorator in node.decorator_list:
+            if isinstance(decorator, ast.Name) and decorator.id == "property":
+                return True
+        return False

--- a/darglint/config.py
+++ b/darglint/config.py
@@ -88,8 +88,9 @@ class LogLevel(Enum):
 class Configuration(object):
 
     def __init__(self, ignore, message_template, style, strictness,
-                 ignore_regex=None, ignore_raise=[], enable=[], indentation=4,
-                 assert_style=AssertStyle.LOG, log_level=LogLevel.CRITICAL):
+                 ignore_regex=None, ignore_raise=[], ignore_properties=False, enable=[],
+                 indentation=4, assert_style=AssertStyle.LOG,
+                 log_level=LogLevel.CRITICAL):
         # type: (List[str], Optional[str], DocstringStyle, Strictness, Optional[str], List[str], List[str], int, AssertStyle, LogLevel) -> None  # noqa: E501
         """Initialize the configuration object.
 
@@ -102,6 +103,8 @@ class Configuration(object):
                 functions/methods by name.
             ignore_raise: A list of exceptions that don't need to be
                 documented.
+            ignore_properties: Bool indicating whether to ignore properties functions
+                or not.
             enable: A list of of error codes that are disabled by default.
             indentation: The number of spaces to count as an indent.
             assert_style: The assert style to use (e.g. log on failed
@@ -116,6 +119,7 @@ class Configuration(object):
         self.errors_to_ignore = self._get_errors_to_ignore()
         self.ignore_regex = ignore_regex
         self.ignore_raise = ignore_raise
+        self.ignore_properties = ignore_properties
         self.indentation = indentation
         self.assert_style = assert_style
         self.log_level = log_level
@@ -232,6 +236,8 @@ def load_config_file(filename):  # type: (str) -> Configuration
             to_ignore_raise = config['darglint']['ignore_raise']
             for exception in to_ignore_raise.split(','):
                 ignore_raise.append(exception.strip())
+        if 'ignore_properties' in config['darglint']:
+            ignore_properties = config['darglint']['ignore_properties']
         if 'docstring_style' in config['darglint']:
             raw_style = config['darglint']['docstring_style']
             style = DocstringStyle.from_string(raw_style)
@@ -260,6 +266,7 @@ def load_config_file(filename):  # type: (str) -> Configuration
         strictness=strictness,
         ignore_regex=ignore_regex,
         ignore_raise=ignore_raise,
+        ignore_properties=ignore_properties,
         enable=enable,
         indentation=indentation,
     )

--- a/darglint/config.py
+++ b/darglint/config.py
@@ -91,7 +91,7 @@ class Configuration(object):
                  ignore_regex=None, ignore_raise=[], ignore_properties=False, enable=[],
                  indentation=4, assert_style=AssertStyle.LOG,
                  log_level=LogLevel.CRITICAL):
-        # type: (List[str], Optional[str], DocstringStyle, Strictness, Optional[str], List[str], List[str], int, AssertStyle, LogLevel) -> None  # noqa: E501
+        # type: (List[str], Optional[str], DocstringStyle, Strictness, Optional[str], List[str], bool, List[str], int, AssertStyle, LogLevel) -> None  # noqa: E501
         """Initialize the configuration object.
 
         Args:
@@ -215,6 +215,7 @@ def load_config_file(filename):  # type: (str) -> Configuration
     message_template = None
     ignore_regex = None
     ignore_raise = list()
+    ignore_properties = False
     style = DocstringStyle.GOOGLE
     strictness = Strictness.FULL_DESCRIPTION
     indentation = 4

--- a/darglint/driver.py
+++ b/darglint/driver.py
@@ -61,6 +61,13 @@ parser.add_argument(
     ),
 )
 parser.add_argument(
+    '--ignore-properties',
+    '-p',
+    action="store_true",
+    default=False,
+    help='Class property methods will be ignored by darglint',
+)
+parser.add_argument(
     '--raise-syntax',
     action='store_true',
     help=(
@@ -302,6 +309,8 @@ def main():
             config.ignore_raise = [
                 x.strip() for x in args.ignore_raise.split(",")
             ]
+        if args.ignore_properties:
+            config.ignore_properties = args.ignore_properties
 
         raise_errors_for_syntax = args.raise_syntax or False
         for filename in files:

--- a/darglint/integrity_checker.py
+++ b/darglint/integrity_checker.py
@@ -125,8 +125,11 @@ class IntegrityChecker(object):
             self.config.ignore_regex and
             re.match(self.config.ignore_regex, function.name)
         )
+        skip_property = (
+            self.config.ignore_properties and function.is_property
+        )
 
-        return bool(no_docsting or skip_by_regex)
+        return bool(no_docsting or skip_by_regex or skip_property)
 
     def _check_parameter_types(self, docstring, function):
         # type: (FunctionDescription) -> None

--- a/tests/test_function_description.py
+++ b/tests/test_function_description.py
@@ -474,3 +474,22 @@ class GetFunctionsAndDocstrings(TestCase):
             function.argument_names,
             [],
         )
+
+    def test_property(self):
+        program = reindent(r'''
+            class A:
+                @property
+                def f() -> int:
+                    return 3
+        ''')
+        tree = ast.parse(program)
+        functions = get_function_descriptions(tree)
+        self.assertEqual(
+            len(functions),
+            1,
+        )
+        function = functions[0]
+        self.assertTrue(
+            function.is_property,
+            [],
+        )

--- a/tests/test_function_description.py
+++ b/tests/test_function_description.py
@@ -489,7 +489,4 @@ class GetFunctionsAndDocstrings(TestCase):
             1,
         )
         function = functions[0]
-        self.assertTrue(
-            function.is_property,
-            [],
-        )
+        self.assertTrue(function.is_property)

--- a/tests/test_integrity_checker.py
+++ b/tests/test_integrity_checker.py
@@ -556,6 +556,42 @@ class IntegrityCheckerTestCase(TestCase):
             errors = checker.errors
             self.assertEqual(len(errors), 1)
 
+    def test_ignore_properties(self):
+        program = '\n'.join([
+            'class A:'
+            '',
+            '    @property',
+            '    def a() -> int:',
+            '        """Property of A"""',
+            '        return 2',
+        ])
+        tree = ast.parse(program)
+        functions = get_function_descriptions(tree)
+        with ConfigurationContext(
+            ignore=[],
+            message_template=None,
+            style=DocstringStyle.GOOGLE,
+            strictness=Strictness.FULL_DESCRIPTION,
+            ignore_properties=False  # Run WITHOUT ignoring properties
+        ):
+            checker = IntegrityChecker()
+            checker.run_checks(functions[0])
+
+            errors = checker.errors
+            self.assertEqual(len(errors), 1)
+        with ConfigurationContext(
+            ignore=[],
+            message_template=None,
+            style=DocstringStyle.GOOGLE,
+            strictness=Strictness.FULL_DESCRIPTION,
+            ignore_properties=True  # Run WITH ignoring properties
+        ):
+            checker = IntegrityChecker()
+            checker.run_checks(functions[0])
+
+            errors = checker.errors
+            self.assertEqual(len(errors), 0)
+
     def test_ignore_style_errors(self):
         program = '\n'.join([
             'class WebsiteChecker:',


### PR DESCRIPTION
User can now set *darglint* to ignore property methods using the `ignore-properties` directive

**Why is it good for us?**
In my codebase, I use the sphinx syntax to document my code. Right now, *darglint* enforce me to add the `:return:` and `:rtype:` section for all property methods. In my opinion, This is redundant since there is no actual need to use this methodologic documentation for property methods. Simple one-liner documentation is sufficient enough in that case and sometimes it is much clearer than a long pedantic description.

Therefore, one is now able to decide whether for *darglint* to skip property methods or not using the `ignore-properties` directive.