### PR TITLE
Add support for `pyproject.toml` for configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def read_full_documentation(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-requirements = []
+requirements = ['tomli']
 
 
 class CleanCommand(Command):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -60,9 +60,10 @@ class WalkPathTestCase(TestCase):
 class FindConfigFileInPathTestCase(TestCase):
     """Test that the config file is being found."""
 
+    @mock.patch('darglint.config.tomli')
     @mock.patch('darglint.config.configparser.ConfigParser')
     @mock.patch('darglint.config.os.listdir')
-    def test_filename_checked(self, mock_listdir, mock_ConfigParser):
+    def test_filename_checked(self, mock_listdir, mock_ConfigParser, mock_tomli):
         """Check that only the necessary filenames are identified.  # noqa """
         fake_files = [
             ''.join([choice(ascii_letters + '_-')
@@ -82,6 +83,12 @@ class FindConfigFileInPathTestCase(TestCase):
             return mock.MagicMock()
 
         config_parser.read = read_file
+        
+        def load_file(reader):
+            contents_checked.append('./' + reader.name)
+            return mock.MagicMock()
+
+        mock_tomli.load = load_file
 
         find_config_file_in_path('./')
 


### PR DESCRIPTION
Add support for configuration using `pyproject.toml`, as specified in [PEP 518](https://www.python.org/dev/peps/pep-0518/).

Inspired by both [`isort`](https://github.com/PyCQA/isort/blob/b06a000a730e5b7036bc1eef3c760f2df9359353/isort/settings.py#L772-L779) and [`mypy`](https://github.com/python/mypy/blob/aede3aefd75332f3911a43bb4a6a98baacce785a/mypy/config_parser.py#L170-L179), I have resorted to the [`tomli`](https://github.com/hukkin/tomli) package for parsing TOML files. As such, this PR introduces the first non-dev dependency to darglint.

Closes #130.