### PR TITLE
Add flag to flake8 to disable darglint

### DIFF
--- a/darglint/flake8_entry.py
+++ b/darglint/flake8_entry.py
@@ -85,15 +85,15 @@ class DarglintChecker(object):
         )
 
         option_manager.add_option(
-            '--darglint-ignore',
-            default=defaults.ignore,
-            parse_from_config=True,
-            nargs='+',
-            help='Codes to ignore for Darglint',
+            '--darglint-disable',
+            default=False,
+            action='store_true',
+            help='Disable Darglint with flake8',
         )
 
     @classmethod
     def parse_options(cls, options):
         cls.config.style = DocstringStyle.from_string(options.docstring_style)
         cls.config.strictness = Strictness.from_string(options.strictness)
-        cls.config.ignore = [error.strip() for error in options.darglint_ignore]
+        if options.darglint_disable:
+            cls.config.ignore = ['*']

--- a/darglint/flake8_entry.py
+++ b/darglint/flake8_entry.py
@@ -84,7 +84,16 @@ class DarglintChecker(object):
             help='Strictness level to use for Darglint',
         )
 
+        option_manager.add_option(
+            '--darglint-ignore',
+            default=defaults.ignore,
+            parse_from_config=True,
+            nargs='+',
+            help='Codes to ignore for Darglint',
+        )
+
     @classmethod
     def parse_options(cls, options):
         cls.config.style = DocstringStyle.from_string(options.docstring_style)
         cls.config.strictness = Strictness.from_string(options.strictness)
+        cls.config.ignore = [error.strip() for error in options.darglint_ignore]


### PR DESCRIPTION
When `darglint` is installed, it is run by `flake8` automatically. This is a good default, but sometimes is undesirable. This PR adds a flag `--darglint-disable` to `flake8` to disable `darglint` on a case-by-case basis.

In my case, running `flake8` on my entire source tree takes 4 minutes when `darglint` is installed, v.s. 4 seconds without. So I want to disable darglint when running `flake8` as a commit hook (where quick response is important), but still run `darglint` when running on continuous integration (where it's still faster than our unit test suite).