### PR TITLE
FIx typo in DAR203 definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ argument as missing.  See Issue #90.)
 - *DAR105*: The docstring parameter type is malformed.
 - *DAR201*: The docstring is missing a return from definition.
 - *DAR202*: The docstring has a return not in definition.
-- *DAR203*: The docstring parameter type doesn't match function.
+- *DAR203*: The docstring return type doesn't match function.
 - *DAR301*: The docstring is missing a yield present in definition.
 - *DAR302*: The docstring has a yield not in definition.
 - *DAR401*: The docstring is missing an exception raised.

--- a/darglint/errors.py
+++ b/darglint/errors.py
@@ -432,7 +432,7 @@ class ReturnTypeMismatchError(DarglintError):
     """Describes when a docstring parameter type doesn't match function."""
 
     error_code = 'DAR203'
-    description = 'The docstring parameter type doesn\'t match function.'
+    description = 'The docstring return type doesn\'t match function.'
 
     def __init__(self, function, expected, actual, line_numbers=None):
         # type: (Union[ast.FunctionDef, ast.AsyncFunctionDef], str, str, Tuple[int, int]) -> None


### PR DESCRIPTION
D203 is about return types, but is copy-pasted "parameter".