### PR TITLE
Support `abc.abstractmethod` in abstract detection

### DIFF
--- a/darglint/analysis/analysis_helpers.py
+++ b/darglint/analysis/analysis_helpers.py
@@ -10,7 +10,13 @@ def _has_decorator(function, decorators):
         decorators = (decorators,)
 
     for decorator in function.decorator_list:
-        # Attributes (setters and getters) won't have an id.
-        if isinstance(decorator, ast.Name) and decorator.id in decorators:
+        decorator_name = None
+        if isinstance(decorator, ast.Name):
+            # Attributes (setters and getters) won't have an id.
+            decorator_name = decorator.id
+        elif isinstance(decorator, ast.Attribute):
+            decorator_name = decorator.attr
+
+        if decorator_name in decorators:
             return True
     return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,5 +36,5 @@ darglint = "darglint.driver:main"
 "DAR" = "darglint.flake8_entry:DarglintChecker"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/test_abstract_callable_visitor.py
+++ b/tests/test_abstract_callable_visitor.py
@@ -26,6 +26,8 @@ class PureAbstractVisitorTests(TestCase):
         self.assertFalse(visitor.is_abstract)
         visitor = self.analyzeAbstract("@abstractmethod\n" + reindent(program))
         self.assertEqual(visitor.is_abstract, result)
+        visitor = self.analyzeAbstract("@abc.abstractmethod\n" + reindent(program))
+        self.assertEqual(visitor.is_abstract, result)
 
     def check_abstract_toggle_doc(self, program, result=True, doc="None"):
         self.check_abstract_decoration(program.format(docstring=""), result)

--- a/tests/test_analysis_visitor.py
+++ b/tests/test_analysis_visitor.py
@@ -74,9 +74,21 @@ class AnalysisVisitorTests(TestCase):
         '''
         self.assertFound(program, 'returns', [1], lambda x: 1)
 
-    def test_finds_abstract(self):
+    def test_finds_bare_abstractmethod(self):
         program = r'''
             @abstractmethod
+            def f(x):
+                """Halves the argument."""
+                pass
+        '''
+        function = ast.parse(reindent(program))
+        visitor = AnalysisVisitor()
+        visitor.visit(function)
+        self.assertTrue(visitor.is_abstract, 'Should have been marked abstract.')
+
+    def test_finds_attribute_abstractmethod(self):
+        program = r'''
+            @abc.abstractmethod
             def f(x):
                 """Halves the argument."""
                 pass


### PR DESCRIPTION
Fixes #183

Specifically, we're allowing any `XYZ.abstractmethod` decorator, as some might roll their own or add bells and whistles on top of `abc.abstractmethod`.