### PR TITLE
Use mypyc for cyk.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,0 +1,8 @@
+def build():
+    try:
+        # try to compile cyk.py if mypy is installed
+        from mypyc.build import mypycify
+
+        return {"ext_modules":  mypycify(["darglint/parse/cyk.py"])}
+    except ImportError:
+        return {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     'Programming Language :: Python :: 3.6',
 ]
 readme = "README.md"
+build = "build.py"
 
 [tool.poetry.dependencies]
 python = "^3.6"
@@ -25,7 +26,7 @@ pytest = "^5.2"
 tox = "^3.14"
 flake8 = "^3.7"
 neovim = "^0.3.1"
-mypy = "^0.812"
+mypy = "^0.931"
 pydocstyle = "^4.0"
 twine = "^3.1"
 
@@ -36,5 +37,5 @@ darglint = "darglint.driver:main"
 "DAR" = "darglint.flake8_entry:DarglintChecker"
 
 [build-system]
-requires = ["poetry>=0.12"]
+requires = ["poetry>=0.12", "mypy", "setuptools"]
 build-backend = "poetry.masonry.api"

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,8 @@ import os
 from setuptools import setup, find_packages, Command
 import subprocess
 
+from build import build
+
 
 def read_full_documentation(fname):
     """Get long documentation from the README.rst.
@@ -46,7 +48,6 @@ class CleanCommand(Command):
 
 flake8_entry_point = 'flake8.extension'
 
-
 setup(
     name="darglint",
     version="1.8.1",
@@ -85,4 +86,5 @@ setup(
     cmdclass={
         'clean': CleanCommand,
     },
+    **build(),
 )


### PR DESCRIPTION
This PR uses mypyc to compile cyk.py to a python c-extension. It would be beneficial to also compile all files that cyk.py imports.

To test the compiled version simply replace `darglint = ...` in pyproject with `darglint = {git = "https://github.com/twoertwein/darglint"}`. 

Compiling cyk.py improves the speed for the numpy and google style. Using the example from @webknjaz in #186:

```sh
wget https://raw.githubusercontent.com/ansible/ansible-navigator/295b1529f461dd3dc69d4271a909ad7ea9a9cac1/src/ansible_navigator/runner/base.py
for style in sphinx numpy google; do echo Checking $style docstrings...; time darglint -s $style base.py &>/dev/null; done
```
official darglint 1.8.1
```
Checking sphinx docstrings...

real    0m0.242s
user    0m0.211s
sys     0m0.032s
Checking numpy docstrings...

real    9m19.110s
user    9m18.890s
sys     0m0.213s
Checking google docstrings...

real    10m33.168s
user    10m32.860s
sys     0m0.276s
```
with this PR and mypy 0.931
```
Checking sphinx docstrings...

real    0m0.245s
user    0m0.217s
sys     0m0.028s
Checking numpy docstrings...

real    2m30.529s
user    2m30.296s
sys     0m0.232s
Checking google docstrings...

real    2m53.705s
user    2m53.473s
sys     0m0.232s
```
