### PR TITLE
Feature: allows ast subscript

### DIFF
--- a/darglint/analysis/argument_visitor.py
+++ b/darglint/analysis/argument_visitor.py
@@ -17,14 +17,14 @@ class ArgumentVisitor(ast.NodeVisitor):
 
         # The arguments found in the function.
         self.arguments = list()  # type: List[str]
-        self.types = list()  # type: List[str]
+        self.annotations = list()  # type: List[ast.Ast]
 
     def add_arg_by_name(self, name, arg):
         self.arguments.append(name)
-        if arg.annotation is not None and hasattr(arg.annotation, 'id'):
-            self.types.append(arg.annotation.id)
+        if arg.annotation is not None:
+            self.annotations.append(arg.annotation)
         else:
-            self.types.append(None)
+            self.annotations.append(None)
 
     def visit_arguments(self, node):
         # type: (ast.arguments) -> ast.AST

--- a/darglint/function_description.py
+++ b/darglint/function_description.py
@@ -147,11 +147,11 @@ class FunctionDescription(object):
             logger.debug(msg)
             return
         self.argument_names = visitor.arguments
-        self.argument_types = visitor.types
+        self.argument_annotations = visitor.annotations
         if function_type != FunctionType.FUNCTION and len(self.argument_names) > 0:
             if not _has_decorator(function, "staticmethod"):
                 self.argument_names.pop(0)
-                self.argument_types.pop(0)
+                self.argument_annotations.pop(0)
         self.has_return = bool(visitor.returns)
         self.has_empty_return = False
         if self.has_return:

--- a/darglint/utils.py
+++ b/darglint/utils.py
@@ -5,6 +5,7 @@ and should ideally be excluded from the sources.
 
 """
 import ast
+from typing import Union, Optional, cast
 
 from ast import (
     AST,
@@ -27,11 +28,11 @@ from .config import (
 class AnnotationsUtils(object):
     @staticmethod
     def parse_annotation_or_types(source):
-        # type: (Optional[str]) -> Optional[ast.Ast]
+        # type: (Optional[str]) -> Optional[ast.AST]
         ast_module = AstNodeUtils.parse(source) if source is not None else None
         if ast_module is None:
             return None
-        return ast_module.body[0].value if len(ast_module.body)>0 else None
+        return cast(Union[ast.Subscript, ast.Expr],ast_module.body[0]).value if len(ast_module.body)>0 else None
 
     @staticmethod
     def parse_types(types):
@@ -74,8 +75,6 @@ class AstNodeUtils(object):
         Returns:
             Return the ast module.
         """
-        # type: (str) -> ast.Module
-
         try:
             return ast.parse(source)
         except SyntaxError as e:
@@ -83,11 +82,11 @@ class AstNodeUtils(object):
 
     @staticmethod
     def dump(nodes, annotate_fields=False):
-        # type: (list[Optional[ast.AST]], bool) -> Union[str,list[str]]
+        # type: (Union[list[Optional[ast.AST]],Optional[ast.AST]], bool) -> Union[List[Optional[str]], str, None]
         """Return a formatted dump of the tree in node. 
 
         Args:
-            nodes: The node list
+            nodes: The node list or one node
             annotate_fields: The returned string will show the names and the values for fields if is true.
 
         Returns:
@@ -97,13 +96,13 @@ class AstNodeUtils(object):
         return_list = True
         if type(nodes) is not list:
             return_list = False
-            nodes = [nodes]
+            nodes = cast(List[Optional[AST]],[nodes])
         res = [ast.dump(node, annotate_fields=annotate_fields) if node is not None else None for node in nodes]
         return res if return_list else res[0]
 
     @staticmethod
     def compare_two_nodes(node1, node2):
-        # type: (list[Optional[ast.AST]], list[Optional[str]]) -> bool
+        # type: (list[Optional[ast.AST]], list[Optional[ast.AST]]) -> bool
         """Return true if node1 is equal to node2.
 
         Check if the dump of node1 is equal to the dump of node2.

--- a/darglint/utils.py
+++ b/darglint/utils.py
@@ -54,10 +54,10 @@ class AnnotationsUtils(object):
         dumped_annotations = AstNodeUtils.dump(annotations)
         parsed_types = AnnotationsUtils.parse_types_and_dump(types)
         if dumped_annotations is not None:
-            dumped_annotations=dumped_annotations.sort(key=lambda x: x or '')
+            dumped_annotations.sort(key=lambda x: x or '')
 
         if parsed_types is not None:
-            parsed_types = parsed_types.sort(key=lambda x: x or '')        
+            parsed_types.sort(key=lambda x: x or '')        
 
         if dumped_annotations != parsed_types:
             raise AssertionError(f"{dumped_annotations} != {parsed_types} ({types})")

--- a/tests/test_argument_visitor.py
+++ b/tests/test_argument_visitor.py
@@ -10,6 +10,10 @@ from .utils import (
     require_python,
 )
 
+from darglint.utils import (
+    AnnotationsUtils,
+)
+
 
 class ArgumentVisitorTests(TestCase):
 
@@ -35,7 +39,7 @@ class ArgumentVisitorTests(TestCase):
         function = ast.parse(reindent(program)).body[0]
         visitor = ArgumentVisitor()
         visitor.visit(function)
-        self.assertEqual(sorted(visitor.types), sorted(types))
+        AnnotationsUtils.assertEqual_annotations_and_types(visitor.annotations, types)
         return visitor
 
     def test_no_arguments(self):

--- a/tests/test_argument_visitor.py
+++ b/tests/test_argument_visitor.py
@@ -1,18 +1,19 @@
 import ast
-from unittest import TestCase
 
 from darglint.analysis.argument_visitor import (
     ArgumentVisitor,
 )
 
-from .utils import (
-    reindent,
-    require_python,
-)
-
 from darglint.utils import (
     AnnotationsUtils,
 )
+
+from .utils import (
+    reindent,
+    require_python,
+    TestCase,
+)
+
 
 
 class ArgumentVisitorTests(TestCase):
@@ -123,6 +124,13 @@ class ArgumentVisitorTests(TestCase):
         '''
         self.assertTypesFound(program, 'int')
 
+    def test_argument_complicated_type_inline(self):
+        program = '''
+            def f(x: {}) -> float:
+                return x * 0.5
+        '''.format(self.complicated_type_hint)
+        self.assertTypesFound(program, self.complicated_type_hint)
+
     def test_no_argument_type(self):
         program = '''
             def f(x) -> str:
@@ -136,3 +144,10 @@ class ArgumentVisitorTests(TestCase):
                 return y * x
         '''
         self.assertTypesFound(program, 'int', 'str')
+
+    def test_multiple_complicated_types_ordered(self):
+        program = '''
+            def f(x: {}, y: str) -> str:
+                return y * x
+        '''.format(self.complicated_type_hint)
+        self.assertTypesFound(program, self.complicated_type_hint, 'str')

--- a/tests/test_function_description.py
+++ b/tests/test_function_description.py
@@ -1,6 +1,7 @@
 import ast
 from unittest import TestCase
 from darglint.function_description import get_function_descriptions
+from darglint.utils import AnnotationsUtils
 from .utils import (
     require_python,
     reindent,
@@ -159,7 +160,7 @@ class GetFunctionsAndDocstrings(TestCase):
         ])
         tree = ast.parse(program)
         function = get_function_descriptions(tree)[0]
-        self.assertEqual(function.argument_types, ['int'])
+        AnnotationsUtils.assertEqual_annotations_and_types(function.argument_annotations, ['int'])
 
     def test_argument_types_are_non_if_not_specified(self):
         program = '\n'.join([
@@ -168,7 +169,7 @@ class GetFunctionsAndDocstrings(TestCase):
         ])
         tree = ast.parse(program)
         function = get_function_descriptions(tree)[0]
-        self.assertEqual(function.argument_types, [None])
+        AnnotationsUtils.assertEqual_annotations_and_types(function.argument_annotations, [None])
 
     def test_extracts_return_type(self):
         program = '\n'.join([
@@ -244,7 +245,7 @@ class GetFunctionsAndDocstrings(TestCase):
         tree = ast.parse(program)
         function = get_function_descriptions(tree)[0]
         self.assertEqual(function.argument_names, ['a', 'b', 'key'])
-        self.assertEqual(function.argument_types, [None, None, None])
+        AnnotationsUtils.assertEqual_annotations_and_types(function.argument_annotations, [None, None, None])
 
     def test_keyword_only_arguments_with_type_hints(self):
         program = '\n'.join([
@@ -254,7 +255,7 @@ class GetFunctionsAndDocstrings(TestCase):
         tree = ast.parse(program)
         function = get_function_descriptions(tree)[0]
         self.assertEqual(function.argument_names, ['a', 'key'])
-        self.assertEqual(function.argument_types, ['int', 'bool'])
+        AnnotationsUtils.assertEqual_annotations_and_types(function.argument_annotations, ['int', 'bool'])
 
     def test_has_assert(self):
         asserting_programs = [

--- a/tests/test_integrity_checker.py
+++ b/tests/test_integrity_checker.py
@@ -32,6 +32,7 @@ from darglint.errors import (
 )
 from darglint.utils import (
     ConfigurationContext,
+    AnnotationsUtils,
 )
 
 from .utils import reindent
@@ -237,7 +238,7 @@ class IntegrityCheckerNumpyTestCase(TestCase):
             '        ----------',
             '        load_name : str',
             '            The load name (one of \'ambient\', \'hot_load\', \'open\' or \'short\').',
-            '        direc : Union[str, Path]',
+            '        direc : [str, Path]',
             '            The top-level calibration observation directory.',
             '        run_num : Optional[int]',
             '            The run number to use for the spectra.',
@@ -875,7 +876,7 @@ class IntegrityCheckerTestCase(TestCase):
         self.assertEqual(len(checker.errors), 1)
         error = checker.errors[0]
         self.assertTrue(isinstance(error, ParameterTypeMismatchError))
-        self.assertEqual(error.expected, 'int')
+        self.assertEqual([error.expected], AnnotationsUtils.parse_types_and_dump(['int']))
         self.assertEqual(error.actual, 'float')
 
     def test_return_type_unchecked_if_not_defined_in_docstring(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,238 @@
+import ast
+
+from darglint.utils import AnnotationsUtils, AstNodeUtils
+
+from .utils import TestCase, reindent
+
+
+class AstNodeUtilsTest(TestCase):
+    # parse
+    def test_parse_error(self):
+        program = '\n'.join([
+            'deftop_level_function(arg):',
+            '    """My docstring"""',
+            '    return 1',
+        ])
+        self.assertIsNone(AstNodeUtils.parse(program))
+
+    def test_parse_ok(self):
+        program = '\n'.join([
+            'def top_level_function(arg):',
+            '    """My docstring"""',
+            '    return 1',
+        ])
+        parsed = AstNodeUtils.parse(program)
+        self.assertIsNotNone(parsed)
+        self.assertIsInstance(parsed, ast.Module)
+        self.assertEqual(parsed.body[0].name, 'top_level_function')
+
+    def test_parse_type_hint(self):
+        program = '\n'.join([
+            'int',
+        ])
+        parsed = AstNodeUtils.parse(program)
+        self.assertIsNotNone(parsed)
+        self.assertIsInstance(parsed, ast.Module)
+        self.assertEqual(parsed.body[0].value.id, 'int')
+
+    def test_parse_complicated_type_hint(self):
+        program = '\n'.join([
+            self.complicated_type_hint,
+        ])
+        parsed = AstNodeUtils.parse(program)
+        self.assertIsNotNone(parsed)
+        self.assertIsInstance(parsed, ast.Module)
+        self.assertEqual(ast.dump(parsed.body[0]), ast.dump(ast.parse(self.complicated_type_hint).body[0]))
+
+    # dump
+    def test_dump_None(self):
+        program = None
+        self.assertIsNone(AstNodeUtils.dump(program))
+
+    def test_dump_None_list(self):
+        program = [None]
+        dumped = AstNodeUtils.dump(program)
+        self.assertIsInstance(dumped, list)
+        self.assertIsNone(dumped[0])
+
+    def test_dump_function(self):
+        program = '\n'.join([
+            'def top_level_function(arg):',
+            '    """My docstring"""',
+            '    return 1',
+        ])
+        parsed = ast.parse(program)
+        dumped = AstNodeUtils.dump(parsed.body[0])
+        self.assertEqual(dumped, ast.dump(parsed.body[0], annotate_fields=False))
+
+    def test_dump_function_list(self):
+        program = '\n'.join([
+            'def top_level_function(arg):',
+            '    """My docstring"""',
+            '    return 1',
+        ])
+        parsed = ast.parse(program)
+        dumped = AstNodeUtils.dump([parsed.body[0]])
+        self.assertIsInstance(dumped, list)
+        self.assertEqual(dumped[0], ast.dump(parsed.body[0], annotate_fields=False))
+
+    def test_dump_type(self):
+        program = '\n'.join([
+            'int',
+        ])
+        parsed = ast.parse(program)
+        dumped = AstNodeUtils.dump(parsed.body[0])
+        self.assertEqual(dumped, ast.dump(parsed.body[0], annotate_fields=False))
+
+    def test_dump_type_list(self):
+        program = '\n'.join([
+            'int',
+        ])
+        parsed = ast.parse(program)
+        dumped = AstNodeUtils.dump([parsed.body[0]])
+        self.assertIsInstance(dumped, list)
+        self.assertEqual(dumped[0], ast.dump(parsed.body[0], annotate_fields=False))
+
+    def test_dump_complicated_type(self):
+        program = '\n'.join([
+            self.complicated_type_hint,
+        ])
+        parsed = ast.parse(program)
+        dumped = AstNodeUtils.dump(parsed.body[0])
+        self.assertEqual(dumped, ast.dump(parsed.body[0], annotate_fields=False))
+
+    def test_dump_complicated_type_list(self):
+        program = '\n'.join([
+            self.complicated_type_hint,
+        ])
+        parsed = ast.parse(program)
+        dumped = AstNodeUtils.dump([parsed.body[0]])
+        self.assertIsInstance(dumped, list)
+        self.assertEqual(dumped[0], ast.dump(parsed.body[0], annotate_fields=False))
+
+    def test_compare_two_nodes(self):
+        program = '\n'.join([
+            self.complicated_type_hint,
+        ])
+
+        parsed = ast.parse(program)
+        dumped = AstNodeUtils.compare_two_nodes(parsed, parsed)
+        self.assertTrue(AstNodeUtils.compare_two_nodes(parsed, parsed))
+
+class AnnotationsUtilsTest(TestCase):
+    def test_parse_annotation_or_types_none(self):
+        program = None
+        self.assertIsNone(AnnotationsUtils.parse_annotation_or_types(program))
+
+    def test_parse_annotation_or_types_error_syntax(self):
+        program = '\n'.join([
+            'deftop_level_function(arg):',
+            '    """My docstring"""',
+            '    return 1',
+        ])
+        self.assertIsNone(AnnotationsUtils.parse_annotation_or_types(program))
+
+    def test_parse_annotation_or_types_error_syntax(self):
+        program = '\n'.join([
+            'deftop_level_function(arg):',
+            '    """My docstring"""',
+            '    return 1',
+        ])
+        self.assertIsNone(AnnotationsUtils.parse_annotation_or_types(program))
+
+    def test_parse_annotation_or_types_nothing(self):
+        program = ''
+        self.assertIsNone(AnnotationsUtils.parse_annotation_or_types(program))
+
+    def test_parse_annotation_or_types_simple(self):
+        program = 'int'
+        self.assertEqual(ast.dump(ast.parse(program).body[0].value), ast.dump(AnnotationsUtils.parse_annotation_or_types(program)))
+
+    def test_parse_annotation_or_types_complicated(self):
+        program = self.complicated_type_hint
+        self.assertEqual(ast.dump(ast.parse(program).body[0].value), ast.dump(AnnotationsUtils.parse_annotation_or_types(program)))
+
+    def test_parse_annotation_or_types_simple_bad(self):
+        program = 'int'
+        self.assertNotEqual(ast.dump(ast.parse('str').body[0].value), ast.dump(AnnotationsUtils.parse_annotation_or_types(program)))
+
+    def test_parse_annotation_or_types_complicated_bad(self):
+        program = self.complicated_type_hint
+        self.assertNotEqual(ast.dump(ast.parse('str').body[0].value), ast.dump(AnnotationsUtils.parse_annotation_or_types(program)))
+
+    # parse_types
+    def test_parse_types_simple(self):
+        program = 'int'
+        self.assertEqual([ast.dump(ast.parse(program).body[0].value)]*2, list(map(ast.dump,AnnotationsUtils.parse_types([program,program]))))
+
+    def test_parse_types_complicated(self):
+        program = self.complicated_type_hint
+        self.assertEqual([ast.dump(ast.parse(program).body[0].value)]*2, list(map(ast.dump,AnnotationsUtils.parse_types([program,program]))))
+
+    def test_parse_types_simple_bad(self):
+        program = 'int'
+        self.assertNotEqual([ast.dump(ast.parse('str').body[0].value)]*2, list(map(ast.dump,AnnotationsUtils.parse_types([program,program]))))
+
+    def test_parse_types_complicated_bad(self):
+        program = self.complicated_type_hint
+        self.assertNotEqual([ast.dump(ast.parse('str').body[0].value)]*2, list(map(ast.dump,AnnotationsUtils.parse_types([program,program]))))
+
+
+    # parse_types_and_dump
+
+    def test_parse_types_and_dump_simple(self):
+        program = 'int'
+        self.assertEqual([ast.dump(ast.parse(program).body[0].value, annotate_fields=False)]*2, AnnotationsUtils.parse_types_and_dump([program,program]))
+
+    def test_parse_types_and_dump_complicated(self):
+        program = self.complicated_type_hint
+        self.assertEqual([ast.dump(ast.parse(program).body[0].value, annotate_fields=False)]*2, AnnotationsUtils.parse_types_and_dump([program,program]))
+
+    def test_parse_types_and_dump_simple_bad(self):
+        program = 'int'
+        self.assertNotEqual([ast.dump(ast.parse('str').body[0].value, annotate_fields=False)]*2, AnnotationsUtils.parse_types_and_dump([program,program]))
+
+    def test_parse_types_and_dump_complicated_bad(self):
+        program = self.complicated_type_hint
+        self.assertNotEqual([ast.dump(ast.parse('str').body[0].value, annotate_fields=False)]*2, AnnotationsUtils.parse_types_and_dump([program,program]))
+
+    # compare_annotations_and_types
+
+    def test_compare_annotations_and_types_simple(self):
+        program = 'int'
+        self.assertTrue(AnnotationsUtils.compare_annotations_and_types([ast.parse(program).body[0].value], [program]))
+
+    def test_compare_annotations_and_types_complicated(self):
+        program = self.complicated_type_hint
+        self.assertTrue(AnnotationsUtils.compare_annotations_and_types([ast.parse(program).body[0].value], [program]))
+
+    def test_compare_annotations_and_types_simple_bad(self):
+        program = 'int'
+        self.assertFalse(AnnotationsUtils.compare_annotations_and_types([ast.parse('str').body[0].value], [program]))
+
+    def test_compare_annotations_and_types_complicated_bad(self):
+        program = self.complicated_type_hint
+        self.assertFalse(AnnotationsUtils.compare_annotations_and_types([ast.parse('str').body[0].value], [program]))
+
+    # assertEqual_annotations_and_types
+    def test_assertEqual_annotations_and_types_simple(self):
+        program = 'int'
+        try:
+            AnnotationsUtils.assertEqual_annotations_and_types([ast.parse(program).body[0].value], [program])
+        except AssertionError:
+            self.fail("test_assertEqual_annotations_and_types_simple() raised AssertionError unexpectedly!")
+
+    def test_assertEqual_annotations_and_types_complicated(self):
+        program = self.complicated_type_hint
+        try:
+            AnnotationsUtils.assertEqual_annotations_and_types([ast.parse(program).body[0].value], [program])
+        except AssertionError:
+            self.fail("test_assertEqual_annotations_and_types_complicated() raised AssertionError unexpectedly!")
+
+    def test_assertEqual_annotations_and_types_simple_bad(self):
+        program = 'int'
+        self.assertRaises(AssertionError, lambda:AnnotationsUtils.assertEqual_annotations_and_types([ast.parse('str').body[0].value], [program]))
+
+    def test_assertEqual_annotations_and_types_complicated_bad(self):
+        program = self.complicated_type_hint
+        self.assertRaises(AssertionError, lambda:AnnotationsUtils.assertEqual_annotations_and_types([ast.parse('str').body[0].value], [program]))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,26 +1,17 @@
 import random
 import string
 import sys
-from typing import (
-    Callable,
-    Iterable,
-    List,
-    Set,
-)
+from typing import Callable, Iterable, List, Set
+from unittest import TestCase as OriginalTestCase
 from unittest import skip
 
-from darglint.token import (
-    TokenType,
-    Token,
-)
-from darglint.config import (
-    get_config,
-    Configuration,
-)
-
+from darglint.config import Configuration, get_config
+from darglint.token import Token, TokenType
 
 REFACTORING_COMPLETE = True
 
+class TestCase(OriginalTestCase):
+    complicated_type_hint = "List[Tuple[int, Optional[float]]]"
 
 def require_python(major=3, minor=8):
     """Skip a unit test if the python version is too old.


### PR DESCRIPTION
Hello, and thank you for dev Darglint 🙂
**This Pr is intended to allow more complicated types hints to be detected for parameters and return.** (With "[")
Ex: List[int], Union[int, str], ....

**TODO** :
- [x] parameters
- [ ] tests
- [ ] return
- [ ] doc
- [ ] change the display depending on the version of python

Explanation : 
- Using ast.dump to transform type hints annotations (ast.AST) into strings..
- Using ast.parse to transform doctring (string) into ast.AST and using ast.dump to transform into string

Why ast.parse/ast.dump ? 
- Because is compatible with python 2 & 3
- Python Standard Library

Pb ?
- Not clear error message for "ParameterTypeMismatchError" :  "actual" is a string but "excepted“ is the ast.dump of the ast.AST 

Alternatives : 
- change solution according to the python version 
  - Python 3.9 : ast.unparse
  - Python 3.8 : ast.get_source_segment
  - Less Python 3.8 : ast.dump and ast.parse
- use others libraries
  - [astunparse](https://github.com/simonpercivall/astunparse)
  - [astmonkey](https://github.com/mutpy/astmonkey)

**Even if it's a draft, I would like your corrections/comments** ✍🏻 🙂


Ex: 
test.py
```python
def fib(self, a: List[int], b: int) -> List[int]:
        """Fibo.

        Parameters
        ----------
        a : List[str]
            the first number
        b : int
            the second number

        Returns
        -------
        List[int]
            the fibo resut
        """
        return a
```
```sh
original_darglint test.py  // no error
darglint test.py  // test.py:fib:0: DAR103:  ~a: expected Subscript(Name('List', Load()), Name('int', Load()), Load()) but was List[str]
```