### PR TITLE
Feature: support ast type hints subscript

### DIFF
--- a/darglint/analysis/argument_visitor.py
+++ b/darglint/analysis/argument_visitor.py
@@ -4,7 +4,7 @@ from typing import (
     Dict,
     List,
 )
-
+from ..utils import unparse
 
 class ArgumentVisitor(ast.NodeVisitor):
     """Reports which arguments a function contains."""
@@ -21,8 +21,8 @@ class ArgumentVisitor(ast.NodeVisitor):
 
     def add_arg_by_name(self, name, arg):
         self.arguments.append(name)
-        if arg.annotation is not None and hasattr(arg.annotation, 'id'):
-            self.types.append(arg.annotation.id)
+        if arg.annotation is not None:
+            self.types.append(unparse(arg.annotation))
         else:
             self.types.append(None)
 

--- a/darglint/function_description.py
+++ b/darglint/function_description.py
@@ -25,7 +25,7 @@ from .config import get_logger
 from .analysis.analysis_helpers import (
     _has_decorator
 )
-
+from .utils import unparse
 
 logger = get_logger()
 
@@ -82,8 +82,8 @@ def _get_all_methods(tree):  # type: (ast.AST) -> Iterator[Union[ast.FunctionDef
 
 def _get_return_type(fn):
     # type: (Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> Optional[str]
-    if fn.returns is not None and hasattr(fn.returns, 'id'):
-        return getattr(fn.returns, 'id')
+    if fn.returns is not None:
+        return unparse(fn.returns)
     return None
 
 

--- a/darglint/utils.py
+++ b/darglint/utils.py
@@ -4,6 +4,8 @@ This file should not be imported into Darglint,
 and should ideally be excluded from the sources.
 
 """
+import sys
+import re
 from ast import (
     AST,
 )
@@ -16,12 +18,20 @@ from typing import (
     Optional,
     Set,
 )
+if sys.version_info >= (3, 9):
+    from ast import unparse as ast_unparse
+else:
+    from astunparse import unparse as ast_unparse
+
 from .node import CykNode
 from .config import (
     get_config,
     Configuration,
 )
 
+def unparse(node):
+    # type (ast.AST) -> str
+    return re.sub("[\n()]","",ast_unparse(node))
 
 class AstNodeUtils(object):
 

--- a/docker-build/Dockerfile.test36
+++ b/docker-build/Dockerfile.test36
@@ -11,7 +11,8 @@ RUN python -m pip install -U pip && \
     python -m pip install pytest \
                           mypy \
                           flake8 \
-                          typing
+                          typing \
+                          astunparse
 
 
 WORKDIR /code/

--- a/docker-build/Dockerfile.test37
+++ b/docker-build/Dockerfile.test37
@@ -11,7 +11,8 @@ RUN python -m pip install -U pip && \
     python -m pip install pytest \
                           mypy \
                           flake8 \
-                          typing
+                          typing \
+                          astunparse
 
 
 WORKDIR /code/

--- a/docker-build/Dockerfile.test38
+++ b/docker-build/Dockerfile.test38
@@ -11,7 +11,8 @@ RUN python -m pip install -U pip && \
     python -m pip install pytest \
                           mypy \
                           flake8 \
-                          typing
+                          typing \ 
+                          astunparse
 
 
 WORKDIR /code/

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,4 +1,15 @@
 [[package]]
+name = "astunparse"
+version = "1.6.3"
+description = "An AST unparser for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.6.1,<2.0"
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -513,7 +524,7 @@ jeepney = ">=0.6"
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -672,9 +683,13 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6"
-content-hash = "bad7755d6a77016aef3a686e290fbc4319c43004d322a87a6d616a8a232b9a48"
+content-hash = "28d75cc8559feaac0d29e08a5d2c299049e101da0cb6349e60566a4b4e1a6e5a"
 
 [metadata.files]
+astunparse = [
+    {file = "astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8"},
+    {file = "astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872"},
+]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
@@ -805,6 +820,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:97e5306482182170ade15c4b0d8386ded995a07d7cc2ca8f27958d34d6736497"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e6a36bb9474218c7a5b27ae476035497a6990e21d04c279884eb10d9b290f1b1"},
     {file = "greenlet-1.1.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:abb7a75ed8b968f3061327c433a0fbd17b729947b400747c334a9c29a9af6c58"},
+    {file = "greenlet-1.1.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:b336501a05e13b616ef81ce329c0e09ac5ed8c732d9ba7e3e983fcc1a9e86965"},
     {file = "greenlet-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:14d4f3cd4e8b524ae9b8aa567858beed70c392fdec26dbdb0a8a418392e71708"},
     {file = "greenlet-1.1.2-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:17ff94e7a83aa8671a25bf5b59326ec26da379ace2ebc4411d690d80a7fbcf23"},
     {file = "greenlet-1.1.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9f3cba480d3deb69f6ee2c1825060177a22c7826431458c697df88e6aeb3caee"},
@@ -817,6 +833,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9d29ca8a77117315101425ec7ec2a47a22ccf59f5593378fc4077ac5b754fce"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:21915eb821a6b3d9d8eefdaf57d6c345b970ad722f856cd71739493ce003ad08"},
     {file = "greenlet-1.1.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eff9d20417ff9dcb0d25e2defc2574d10b491bf2e693b4e491914738b7908168"},
+    {file = "greenlet-1.1.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b8c008de9d0daba7b6666aa5bbfdc23dcd78cafc33997c9b7741ff6353bafb7f"},
     {file = "greenlet-1.1.2-cp36-cp36m-win32.whl", hash = "sha256:32ca72bbc673adbcfecb935bb3fb1b74e663d10a4b241aaa2f5a75fe1d1f90aa"},
     {file = "greenlet-1.1.2-cp36-cp36m-win_amd64.whl", hash = "sha256:f0214eb2a23b85528310dad848ad2ac58e735612929c8072f6093f3585fd342d"},
     {file = "greenlet-1.1.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:b92e29e58bef6d9cfd340c72b04d74c4b4e9f70c9fa7c78b674d1fec18896dc4"},
@@ -825,6 +842,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1e12bdc622676ce47ae9abbf455c189e442afdde8818d9da983085df6312e7a1"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8c790abda465726cfb8bb08bd4ca9a5d0a7bd77c7ac1ca1b839ad823b948ea28"},
     {file = "greenlet-1.1.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f276df9830dba7a333544bd41070e8175762a7ac20350786b322b714b0e654f5"},
+    {file = "greenlet-1.1.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:8c5d5b35f789a030ebb95bff352f1d27a93d81069f2adb3182d99882e095cefe"},
     {file = "greenlet-1.1.2-cp37-cp37m-win32.whl", hash = "sha256:64e6175c2e53195278d7388c454e0b30997573f3f4bd63697f88d855f7a6a1fc"},
     {file = "greenlet-1.1.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b11548073a2213d950c3f671aa88e6f83cda6e2fb97a8b6317b1b5b33d850e06"},
     {file = "greenlet-1.1.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:9633b3034d3d901f0a46b7939f8c4d64427dfba6bbc5a36b1a67364cf148a1b0"},
@@ -833,6 +851,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e859fcb4cbe93504ea18008d1df98dee4f7766db66c435e4882ab35cf70cac43"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00e44c8afdbe5467e4f7b5851be223be68adb4272f44696ee71fe46b7036a711"},
     {file = "greenlet-1.1.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ec8c433b3ab0419100bd45b47c9c8551248a5aee30ca5e9d399a0b57ac04651b"},
+    {file = "greenlet-1.1.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2bde6792f313f4e918caabc46532aa64aa27a0db05d75b20edfc5c6f46479de2"},
     {file = "greenlet-1.1.2-cp38-cp38-win32.whl", hash = "sha256:288c6a76705dc54fba69fbcb59904ae4ad768b4c768839b8ca5fdadec6dd8cfd"},
     {file = "greenlet-1.1.2-cp38-cp38-win_amd64.whl", hash = "sha256:8d2f1fb53a421b410751887eb4ff21386d119ef9cde3797bf5e7ed49fb51a3b3"},
     {file = "greenlet-1.1.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:166eac03e48784a6a6e0e5f041cfebb1ab400b394db188c48b3a84737f505b67"},
@@ -841,6 +860,7 @@ greenlet = [
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b1692f7d6bc45e3200844be0dba153612103db241691088626a33ff1f24a0d88"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7227b47e73dedaa513cdebb98469705ef0d66eb5a1250144468e9c3097d6b59b"},
     {file = "greenlet-1.1.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7ff61ff178250f9bb3cd89752df0f1dd0e27316a8bd1465351652b1b4a4cdfd3"},
+    {file = "greenlet-1.1.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:0051c6f1f27cb756ffc0ffbac7d2cd48cb0362ac1736871399a739b2885134d3"},
     {file = "greenlet-1.1.2-cp39-cp39-win32.whl", hash = "sha256:f70a9e237bb792c7cc7e44c531fd48f5897961701cdaa06cf22fc14965c496cf"},
     {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.6"
+astunparse = "^1.6.3"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def read_full_documentation(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
-requirements = []
+requirements = ['astunparse>=1.6.3,<2.0.0']
 
 
 class CleanCommand(Command):

--- a/tests/test_integrity_checker.py
+++ b/tests/test_integrity_checker.py
@@ -226,7 +226,7 @@ class IntegrityCheckerNumpyTestCase(TestCase):
             '    def from_load_name(',
             '        cls,',
             '        load_name: str,',
-            '        direc: [str, Path],',
+            '        direc: Union[str, Path],',
             '        run_num: Optional[int] = None,',
             '        filetype: Optional[str] = None,',
             '        **kwargs',


### PR DESCRIPTION
Hello, and thank you for dev Darglint 🙂
**This Pr is intended to allow more complicated types hints to be detected for parameters and return**. (With "[")
Ex: List[int], Union[int, str], ....

Solution : 
-   For python < 3.9 [astunparse](https://github.com/simonpercivall/astunparse)
-  For python >=3 .9 [ast.unparse](https://docs.python.org/3.10/library/ast.html#ast.unparse)


Ex: 
test.py
```python
def fib(self, a: List[int], b: int) -> List[int]:
        """Fibo.

        Parameters
        ----------
        a : List[str]
            the first number
        b : int
            the second number

        Returns
        -------
        List[str]
            the fibo resut
        """
        return a
```
```sh
original_darglint test.py  
// no error
darglint test.py  
// test.py:fib:0: DAR103:  ~a: expected List[int] but was List[str]
// test.py:fib:0: DAR203:  ~Return: expected List[int] but was List[str]
```